### PR TITLE
Fix framestack for run atari acer

### DIFF
--- a/stable_baselines/acer/run_atari.py
+++ b/stable_baselines/acer/run_atari.py
@@ -19,7 +19,7 @@ def train(env_id, num_timesteps, seed, policy, lr_schedule, num_cpu):
                                  'double_linear_con', 'middle_drop' or 'double_middle_drop')
     :param num_cpu: (int) The number of cpu to train on
     """
-    env = VecFrameStack(make_atari_env(env_id, num_env, seed), 4)
+    env = VecFrameStack(make_atari_env(env_id, num_cpu, seed), 4)
     if policy == 'cnn':
         policy_fn = CnnPolicy
     elif policy == 'lstm':

--- a/stable_baselines/acer/run_atari.py
+++ b/stable_baselines/acer/run_atari.py
@@ -4,6 +4,7 @@ from stable_baselines import logger
 from stable_baselines.acer import ACER
 from stable_baselines.common.policies import CnnPolicy, CnnLstmPolicy
 from stable_baselines.common.cmd_util import make_atari_env, atari_arg_parser
+from stable_baselines.common.vec_env import VecFrameStack
 
 
 def train(env_id, num_timesteps, seed, policy, lr_schedule, num_cpu):
@@ -18,7 +19,7 @@ def train(env_id, num_timesteps, seed, policy, lr_schedule, num_cpu):
                                  'double_linear_con', 'middle_drop' or 'double_middle_drop')
     :param num_cpu: (int) The number of cpu to train on
     """
-    env = make_atari_env(env_id, num_cpu, seed)
+    env = VecFrameStack(make_atari_env(env_id, num_env, seed), 4)
     if policy == 'cnn':
         policy_fn = CnnPolicy
     elif policy == 'lstm':


### PR DESCRIPTION
Since the refactoring, the stacking is not done in the acer buffer anymore.
This PR updates the atari example.