### PR TITLE
Allow the callback to abort training for early stopping.

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -132,6 +132,7 @@ Using Callback: Monitoring Training
 You can define a custom callback function that will be called inside the agent.
 This could be useful when you want to monitor training, for instance display live
 learning curves in Tensorboard (or in Visdom) or save the best agent.
+If your callback returns False, training is aborted early.
 
 .. image:: ../_static/img/try_it.png
    :scale: 30 %
@@ -182,7 +183,7 @@ learning curves in Tensorboard (or in Visdom) or save the best agent.
                 print("Saving new best model")
                 _locals['self'].save(log_dir + 'best_model.pkl')
     n_steps += 1
-    return False
+    return True
 
 
   # Create log dir

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -227,6 +227,8 @@ class A2C(ActorCriticRLModel):
                                                                       writer, update * (self.n_batch + 1))
 
                 if callback is not None:
+                    # Only stop training if return value is False, not when it is None. This is for backwards
+                    # compatibility with callbacks that have no return statement.
                     if callback(locals(), globals()) == False:
                         break
 

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -227,7 +227,8 @@ class A2C(ActorCriticRLModel):
                                                                       writer, update * (self.n_batch + 1))
 
                 if callback is not None:
-                    callback(locals(), globals())
+                    if callback(locals(), globals()) == False:
+                        break
 
                 if self.verbose >= 1 and (update % log_interval == 0 or update == 1):
                     explained_var = explained_variance(values, rewards)

--- a/stable_baselines/acer/acer_simple.py
+++ b/stable_baselines/acer/acer_simple.py
@@ -486,6 +486,8 @@ class ACER(ActorCriticRLModel):
                                                          steps, writer)
 
                 if callback is not None:
+                    # Only stop training if return value is False, not when it is None. This is for backwards
+                    # compatibility with callbacks that have no return statement.
                     if callback(locals(), globals()) == False:
                         break
 

--- a/stable_baselines/acer/acer_simple.py
+++ b/stable_baselines/acer/acer_simple.py
@@ -486,7 +486,8 @@ class ACER(ActorCriticRLModel):
                                                          steps, writer)
 
                 if callback is not None:
-                    callback(locals(), globals())
+                    if callback(locals(), globals()) == False:
+                        break
 
                 if self.verbose >= 1 and (int(steps / runner.n_batch) % log_interval == 0):
                     logger.record_tabular("total_timesteps", steps)

--- a/stable_baselines/acktr/acktr_cont.py
+++ b/stable_baselines/acktr/acktr_cont.py
@@ -159,8 +159,9 @@ def learn(env, policy, value_fn, gamma, lam, timesteps_per_batch, num_timesteps,
         logger.record_tabular("EpRewSEM", np.std([path["reward"].sum() / np.sqrt(len(paths)) for path in paths]))
         logger.record_tabular("EpLenMean", np.mean([path["reward"].shape[0] for path in paths]))
         logger.record_tabular("KL", kl_loss)
-        if callback:
-            callback()
+        if callback is not None:
+            if callback(locals(), globals()) == False:
+                break
         logger.dump_tabular()
         i += 1
 

--- a/stable_baselines/acktr/acktr_cont.py
+++ b/stable_baselines/acktr/acktr_cont.py
@@ -160,6 +160,8 @@ def learn(env, policy, value_fn, gamma, lam, timesteps_per_batch, num_timesteps,
         logger.record_tabular("EpLenMean", np.mean([path["reward"].shape[0] for path in paths]))
         logger.record_tabular("KL", kl_loss)
         if callback is not None:
+            # Only stop training if return value is False, not when it is None. This is for backwards
+            # compatibility with callbacks that have no return statement.
             if callback(locals(), globals()) == False:
                 break
         logger.dump_tabular()

--- a/stable_baselines/acktr/acktr_disc.py
+++ b/stable_baselines/acktr/acktr_disc.py
@@ -292,6 +292,8 @@ class ACKTR(ActorCriticRLModel):
                                                                       writer, update * (self.n_batch + 1))
 
                 if callback is not None:
+                    # Only stop training if return value is False, not when it is None. This is for backwards
+                    # compatibility with callbacks that have no return statement.
                     if callback(locals(), globals()) == False:
                         break
 

--- a/stable_baselines/acktr/acktr_disc.py
+++ b/stable_baselines/acktr/acktr_disc.py
@@ -292,7 +292,8 @@ class ACKTR(ActorCriticRLModel):
                                                                       writer, update * (self.n_batch + 1))
 
                 if callback is not None:
-                    callback(locals(), globals())
+                    if callback(locals(), globals()) == False:
+                        break
 
                 if self.verbose >= 1 and (update % log_interval == 0 or update == 1):
                     explained_var = explained_variance(values, rewards)

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -139,8 +139,8 @@ class BaseRLModel(ABC):
 
         :param total_timesteps: (int) The total number of samples to train on
         :param seed: (int) The initial seed for training, if None: keep current seed
-        :param callback: (function (dict, dict)) function called at every steps with state of the algorithm.
-            It takes the local and global variables.
+        :param callback: (function (dict, dict)) -> boolean function called at every steps with state of the algorithm.
+            It takes the local and global variables. If it returns False, training is aborted.
         :param log_interval: (int) The number of timesteps before logging.
         :param tb_log_name: (str) the name of the run for tensorboard log
         :return: (BaseRLModel) the trained model

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -807,6 +807,8 @@ class DDPG(OffPolicyRLModel):
                             self._store_transition(obs, action, reward, new_obs, done)
                             obs = new_obs
                             if callback is not None:
+                                # Only stop training if return value is False, not when it is None. This is for backwards
+                                # compatibility with callbacks that have no return statement.
                                 if callback(locals(), globals()) == False:
                                     return self
 

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -807,7 +807,8 @@ class DDPG(OffPolicyRLModel):
                             self._store_transition(obs, action, reward, new_obs, done)
                             obs = new_obs
                             if callback is not None:
-                                callback(locals(), globals())
+                                if callback(locals(), globals()) == False:
+                                    return self
 
                             if done:
                                 # Episode done.

--- a/stable_baselines/deepq/dqn.py
+++ b/stable_baselines/deepq/dqn.py
@@ -159,6 +159,8 @@ class DQN(OffPolicyRLModel):
 
             for step in range(total_timesteps):
                 if callback is not None:
+                    # Only stop training if return value is False, not when it is None. This is for backwards
+                    # compatibility with callbacks that have no return statement.
                     if callback(locals(), globals()) == False:
                         break
                 # Take action and update exploration to the newest value

--- a/stable_baselines/deepq/dqn.py
+++ b/stable_baselines/deepq/dqn.py
@@ -159,7 +159,8 @@ class DQN(OffPolicyRLModel):
 
             for step in range(total_timesteps):
                 if callback is not None:
-                    callback(locals(), globals())
+                    if callback(locals(), globals()) == False:
+                        break
                 # Take action and update exploration to the newest value
                 kwargs = {}
                 if not self.param_noise:

--- a/stable_baselines/deepq/experiments/train_cartpole.py
+++ b/stable_baselines/deepq/experiments/train_cartpole.py
@@ -20,7 +20,7 @@ def callback(lcl, _glb):
     else:
         mean_100ep_reward = round(float(np.mean(lcl['episode_rewards'][-101:-1])), 1)
     is_solved = lcl['step'] > 100 and mean_100ep_reward >= 199
-    return is_solved
+    return not is_solved
 
 
 def main(args):

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -199,6 +199,8 @@ class PPO1(ActorCriticRLModel):
 
                 while True:
                     if callback is not None:
+                        # Only stop training if return value is False, not when it is None. This is for backwards
+                        # compatibility with callbacks that have no return statement.
                         if callback(locals(), globals()) == False:
                             break
                     if total_timesteps and timesteps_so_far >= total_timesteps:

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -198,8 +198,9 @@ class PPO1(ActorCriticRLModel):
                 self.episode_reward = np.zeros((self.n_envs,))
 
                 while True:
-                    if callback:
-                        callback(locals(), globals())
+                    if callback is not None:
+                        if callback(locals(), globals()) == False:
+                            break
                     if total_timesteps and timesteps_so_far >= total_timesteps:
                         break
 

--- a/stable_baselines/ppo2/ppo2.py
+++ b/stable_baselines/ppo2/ppo2.py
@@ -331,6 +331,8 @@ class PPO2(ActorCriticRLModel):
                     logger.dumpkvs()
 
                 if callback is not None:
+                    # Only stop training if return value is False, not when it is None. This is for backwards
+                    # compatibility with callbacks that have no return statement.
                     if callback(locals(), globals()) == False:
                         break
 

--- a/stable_baselines/ppo2/ppo2.py
+++ b/stable_baselines/ppo2/ppo2.py
@@ -316,9 +316,6 @@ class PPO2(ActorCriticRLModel):
                                                                       masks.reshape((self.n_envs, self.n_steps)),
                                                                       writer, update * (self.n_batch + 1))
 
-                if callback is not None:
-                    callback(locals(), globals())
-
                 if self.verbose >= 1 and (update % log_interval == 0 or update == 1):
                     explained_var = explained_variance(values, returns)
                     logger.logkv("serial_timesteps", (update + 1) * self.n_steps)
@@ -332,6 +329,10 @@ class PPO2(ActorCriticRLModel):
                     for (loss_val, loss_name) in zip(loss_vals, self.loss_names):
                         logger.logkv(loss_name, loss_val)
                     logger.dumpkvs()
+
+                if callback is not None:
+                    if callback(locals(), globals()) == False:
+                        break
 
             return self
 

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -279,6 +279,8 @@ class TRPO(ActorCriticRLModel):
 
                 while True:
                     if callback is not None:
+                        # Only stop training if return value is False, not when it is None. This is for backwards
+                        # compatibility with callbacks that have no return statement.
                         if callback(locals(), globals()) == False:
                             break
                     if total_timesteps and timesteps_so_far >= total_timesteps:

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -278,8 +278,9 @@ class TRPO(ActorCriticRLModel):
                                            sess=self.sess)
 
                 while True:
-                    if callback:
-                        callback(locals(), globals())
+                    if callback is not None:
+                        if callback(locals(), globals()) == False:
+                            break
                     if total_timesteps and timesteps_so_far >= total_timesteps:
                         break
 


### PR DESCRIPTION
Oh my gosh this PR solves issues #96 and #97 at once !11 It even adds the new feature to the documentation! If you are honest, this is the kind of PR you like. It's a great PR! You really want to merge it soon ...

The callback explicitly has to return `False` before training is aborted. Since `False != None` in Python, this implementation is backwards compatible to existing callbacks that have no return statement.

Note: I did not touch HER.