### PR TITLE
Allow nd arrays for MultiDiscrete

### DIFF
--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -266,9 +266,9 @@ class BaseRLModel(ABC):
                 raise ValueError("Error: Unexpected observation shape {} for ".format(observation.shape) +
                                  "Discrete environment, please use (1,) or (n_env, 1) for the observation shape.")
         elif isinstance(observation_space, gym.spaces.MultiDiscrete):
-            if observation.shape == (len(observation_space.nvec),):
+            if observation.shape == observation_space.shape:
                 return False
-            elif len(observation.shape) == 2 and observation.shape[1] == len(observation_space.nvec):
+            elif observation.shape[1:] == observation_space.shape:
                 return True
             else:
                 raise ValueError("Error: Unexpected observation shape {} for MultiDiscrete ".format(observation.shape) +

--- a/stable_baselines/common/input.py
+++ b/stable_baselines/common/input.py
@@ -39,11 +39,8 @@ def observation_input(ob_space, batch_size=None, name='Ob', scale=False):
         return observation_ph, processed_observations
 
     elif isinstance(ob_space, MultiDiscrete):
-        observation_ph = tf.placeholder(shape=(batch_size, len(ob_space.nvec)), dtype=tf.int32, name=name)
-        processed_observations = tf.concat([
-            tf.to_float(tf.one_hot(input_split, ob_space.nvec[i])) for i, input_split
-            in enumerate(tf.split(observation_ph, len(ob_space.nvec), axis=-1))
-        ], axis=-1)
+        observation_ph = tf.placeholder(shape=(batch_size,) + ob_space.shape, dtype=tf.int32, name=name)
+        processed_observations = tf.to_float(tf.one_hot(observation_ph, np.max(ob_space.nvec)))
         return observation_ph, processed_observations
 
     else:


### PR DESCRIPTION
Starting from gym version 0.10.6, nd arrays are allowed for
MultiDiscrete spaces, i.e: MultiDiscrete([[3, 4], [4, 4]]).
To support this, instead of concatenating the one-hot encoded discrete
variables, in order to preserve the original structure, we could use
the maximal cardinality of all variables for one-hot encoding, thus
transforming above (2, 2) shaped observation into a (2, 2, 4).

Fixes #151.