### PR TITLE
Typos in the doc

### DIFF
--- a/docs/guide/custom_env.rst
+++ b/docs/guide/custom_env.rst
@@ -48,7 +48,7 @@ You can find a `complete guide online <https://github.com/openai/gym/tree/master
 on creating a custom Gym environment.
 
 
-Optionnaly, you can also register the environment with gym,
+Optionally, you can also register the environment with gym,
 that will allow you to create the RL agent in one line (and use ``gym.make()`` to instantiate the env).
 
 

--- a/docs/guide/custom_policy.rst
+++ b/docs/guide/custom_policy.rst
@@ -166,7 +166,7 @@ If your task requires even more granular control over the policy architecture, y
           with tf.variable_scope("model", reuse=reuse):
               activ = tf.nn.relu
 
-              extracted_features = nature_cnn(self.self.processed_obs, **kwargs)
+              extracted_features = nature_cnn(self.processed_obs, **kwargs)
               extracted_features = tf.layers.flatten(extracted_features)
 
               pi_h = extracted_features

--- a/docs/guide/custom_policy.rst
+++ b/docs/guide/custom_policy.rst
@@ -30,18 +30,20 @@ However, you can also easily define a custom architecture for the policy (or val
   model = A2C(CustomPolicy, env, verbose=1)
   # Train the agent
   model.learn(total_timesteps=100000)
+  # Save the agent
+  model.save("a2c-lunar")
 
   del model
   # When loading a model with a custom policy
   # you MUST pass explicitly the policy when loading the saved model
-  model = A2C.load(policy=CustomPolicy)
+  model = A2C.load("a2c-lunar", policy=CustomPolicy)
 
 .. warning::
 
   When loading a model with a custom policy, you must pass the custom policy explicitly when loading the model. (cf previous example)
 
 
-You can also registered your policy, to help with code simplicity: you can refer to your custom policy using a string.
+You can also register your policy, to help with code simplicity: you can refer to your custom policy using a string.
 
 .. code-block:: python
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -214,4 +214,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle
+@EliasHasle @mrakgr

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -214,4 +214,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle @mrakgr
+@EliasHasle @mrakgr @Bleyddyn

--- a/docs/modules/a2c.rst
+++ b/docs/modules/a2c.rst
@@ -24,7 +24,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️
 -  Gym spaces:
 

--- a/docs/modules/acer.rst
+++ b/docs/modules/acer.rst
@@ -20,7 +20,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️
 -  Gym spaces:
 

--- a/docs/modules/acktr.rst
+++ b/docs/modules/acktr.rst
@@ -21,7 +21,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️
 -  Gym spaces:
 

--- a/docs/modules/ddpg.rst
+++ b/docs/modules/ddpg.rst
@@ -35,7 +35,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ❌
+-  Recurrent policies: ❌
 -  Multi processing: ❌
 -  Gym spaces:
 

--- a/docs/modules/dqn.rst
+++ b/docs/modules/dqn.rst
@@ -33,7 +33,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ❌
+-  Recurrent policies: ❌
 -  Multi processing: ❌
 -  Gym spaces:
 

--- a/docs/modules/gail.rst
+++ b/docs/modules/gail.rst
@@ -73,7 +73,7 @@ Thanks to the open source:
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️ (using MPI)
 -  Gym spaces:
 

--- a/docs/modules/ppo1.rst
+++ b/docs/modules/ppo1.rst
@@ -31,7 +31,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️ (using MPI)
 -  Gym spaces:
 

--- a/docs/modules/ppo2.rst
+++ b/docs/modules/ppo2.rst
@@ -37,7 +37,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️
 -  Gym spaces:
 

--- a/docs/modules/sac.rst
+++ b/docs/modules/sac.rst
@@ -46,7 +46,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ❌
+-  Recurrent policies: ❌
 -  Multi processing: ❌
 -  Gym spaces:
 

--- a/docs/modules/trpo.rst
+++ b/docs/modules/trpo.rst
@@ -21,7 +21,7 @@ Notes
 Can I use?
 ----------
 
--  Reccurent policies: ✔️
+-  Recurrent policies: ✔️
 -  Multi processing: ✔️  (using MPI)
 -  Gym spaces:
 


### PR DESCRIPTION
Note that it is not only ACKTR which has this typo, but A2C and all the other ones as well. Right now I am editing from the browser, so do you mind fixing the others yourself? Thank you.