### PR TITLE
TRPO, PPO1 - fix EpThisIter, EpisodesSoFar and TimestepsSoFar

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ Pre-Release 2.4.0a (WIP)
 - added more flexible custom LSTM policies
 - added auto entropy coefficient optimization for SAC
 - clip continuous actions at test time too for all algorithms (except SAC/DDPG where it is not needed)
+- fixed computation of training metrics in TRPO and PPO1
 
 
 Release 2.3.0 (2018-12-05)
@@ -214,4 +215,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle @mrakgr @Bleyddyn
+@EliasHasle @mrakgr @Bleyddyn @antoine-galataud

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -297,8 +297,10 @@ class PPO1(ActorCriticRLModel):
                     lens, rews = map(flatten_lists, zip(*listoflrpairs))
                     lenbuffer.extend(lens)
                     rewbuffer.extend(rews)
-                    logger.record_tabular("EpLenMean", np.mean(lenbuffer))
-                    logger.record_tabular("EpRewMean", np.mean(rewbuffer))
+                    if len(lenbuffer) > 0:
+                        logger.record_tabular("EpLenMean", np.mean(lenbuffer))
+                    if len(rewbuffer) > 0:
+                        logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     logger.record_tabular("EpThisIter", len(lens))
                     episodes_so_far += len(lens)
                     timesteps_so_far += MPI.COMM_WORLD.allreduce(seg["total_timestep"])

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -299,7 +299,6 @@ class PPO1(ActorCriticRLModel):
                     rewbuffer.extend(rews)
                     if len(lenbuffer) > 0:
                         logger.record_tabular("EpLenMean", np.mean(lenbuffer))
-                    if len(rewbuffer) > 0:
                         logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     logger.record_tabular("EpThisIter", len(lens))
                     episodes_so_far += len(lens)

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -191,6 +191,8 @@ class PPO1(ActorCriticRLModel):
                 prev_timesteps_so_far = 0
                 # timesteps count after last reset
                 total_timestep = 0
+                # number of episodes done in an iteration
+                ep_done = 0
                 # current total count of timesteps
                 def timesteps_so_far():
                     return prev_timesteps_so_far + total_timestep
@@ -283,6 +285,11 @@ class PPO1(ActorCriticRLModel):
                             losses.append(newlosses)
                         logger.log(fmt_row(13, np.mean(losses, axis=0)))
 
+                    # update global timesteps count only when both losses 
+                    # and timesteps so far metrics are recorded
+                    if ep_done > 0:
+                        prev_timesteps_so_far += total_timestep
+
                     logger.log("Evaluating losses...")
                     losses = []
                     for batch in dataset.iterate_once(optim_batchsize):
@@ -313,7 +320,6 @@ class PPO1(ActorCriticRLModel):
                     logger.record_tabular("TimestepsSoFar", timesteps_so_far())
                     if ep_done > 0:
                         episodes_so_far += ep_done
-                        prev_timesteps_so_far = prev_timesteps_so_far + total_timestep
                     iters_so_far += 1
                     logger.record_tabular("EpisodesSoFar", episodes_so_far)
                     logger.record_tabular("TimeElapsed", time.time() - t_start)

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -187,7 +187,13 @@ class PPO1(ActorCriticRLModel):
                 seg_gen = traj_segment_generator(self.policy_pi, self.env, self.timesteps_per_actorbatch)
 
                 episodes_so_far = 0
-                timesteps_so_far = 0
+                # total timesteps count before last reset
+                prev_timesteps_so_far = 0
+                # timesteps count after last reset
+                total_timestep = 0
+                # current total count of timesteps
+                def timesteps_so_far():
+                    return prev_timesteps_so_far + total_timestep
                 iters_so_far = 0
                 t_start = time.time()
 
@@ -204,13 +210,13 @@ class PPO1(ActorCriticRLModel):
                         # compatibility with callbacks that have no return statement.
                         if callback(locals(), globals()) == False:
                             break
-                    if total_timesteps and timesteps_so_far >= total_timesteps:
+                    if total_timesteps and timesteps_so_far() >= total_timesteps:
                         break
 
                     if self.schedule == 'constant':
                         cur_lrmult = 1.0
                     elif self.schedule == 'linear':
-                        cur_lrmult = max(1.0 - float(timesteps_so_far) / total_timesteps, 0)
+                        cur_lrmult = max(1.0 - float(timesteps_so_far()) / total_timesteps, 0)
                     else:
                         raise NotImplementedError
 
@@ -227,7 +233,7 @@ class PPO1(ActorCriticRLModel):
                         self.episode_reward = total_episode_reward_logger(self.episode_reward,
                                                                           seg["true_rew"].reshape((self.n_envs, -1)),
                                                                           seg["dones"].reshape((self.n_envs, -1)),
-                                                                          writer, timesteps_so_far)
+                                                                          writer, timesteps_so_far())
 
                     # predicted value function before udpate
                     vpredbefore = seg["vpred"]
@@ -248,7 +254,7 @@ class PPO1(ActorCriticRLModel):
                         # list of tuples, each of which gives the loss for a minibatch
                         losses = []
                         for i, batch in enumerate(dataset.iterate_once(optim_batchsize)):
-                            steps = (timesteps_so_far +
+                            steps = (timesteps_so_far() +
                                      k * optim_batchsize +
                                      int(i * (optim_batchsize / len(dataset.data_map))))
                             if writer is not None:
@@ -299,12 +305,17 @@ class PPO1(ActorCriticRLModel):
                     rewbuffer.extend(rews)
                     logger.record_tabular("EpLenMean", np.mean(lenbuffer))
                     logger.record_tabular("EpRewMean", np.mean(rewbuffer))
-                    logger.record_tabular("EpThisIter", len(lens))
-                    episodes_so_far += len(lens)
-                    timesteps_so_far += MPI.COMM_WORLD.allreduce(seg["total_timestep"])
+                    # count number of episodes done this iteration
+                    ep_done = (MPI.COMM_WORLD.allreduce(seg["dones"]) == True).sum()
+                    logger.record_tabular("EpThisIter", ep_done)
+                    # total timesteps between 2 resets
+                    total_timestep = MPI.COMM_WORLD.allreduce(seg["total_timestep"])
+                    logger.record_tabular("TimestepsSoFar", timesteps_so_far())
+                    if ep_done > 0:
+                        episodes_so_far += ep_done
+                        prev_timesteps_so_far = prev_timesteps_so_far + total_timestep
                     iters_so_far += 1
                     logger.record_tabular("EpisodesSoFar", episodes_so_far)
-                    logger.record_tabular("TimestepsSoFar", timesteps_so_far)
                     logger.record_tabular("TimeElapsed", time.time() - t_start)
                     if self.verbose >= 1 and MPI.COMM_WORLD.Get_rank() == 0:
                         logger.dump_tabular()

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -119,12 +119,12 @@ class TRPO(ActorCriticRLModel):
 
                 # Construct network for new policy
                 self.policy_pi = self.policy(self.sess, self.observation_space, self.action_space, self.n_envs, 1,
-                                             None, reuse=False)
+                                             None, reuse=False, **self.policy_kwargs)
 
                 # Network for old policy
                 with tf.variable_scope("oldpi", reuse=False):
                     old_policy = self.policy(self.sess, self.observation_space, self.action_space, self.n_envs, 1,
-                                             None, reuse=False)
+                                             None, reuse=False, **self.policy_kwargs)
 
                 with tf.variable_scope("loss", reuse=False):
                     atarg = tf.placeholder(dtype=tf.float32, shape=[None])  # Target advantage function (if applicable)

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -258,7 +258,13 @@ class TRPO(ActorCriticRLModel):
                                                  reward_giver=self.reward_giver, gail=self.using_gail)
 
                 episodes_so_far = 0
-                timesteps_so_far = 0
+                # total timesteps count before last reset
+                prev_timesteps_so_far = 0
+                # timesteps count after last reset
+                total_timestep = 0
+                # current total count of timesteps
+                def timesteps_so_far():
+                    return prev_timesteps_so_far + total_timestep
                 iters_so_far = 0
                 t_start = time.time()
                 lenbuffer = deque(maxlen=40)  # rolling buffer for episode lengths
@@ -284,7 +290,7 @@ class TRPO(ActorCriticRLModel):
                         # compatibility with callbacks that have no return statement.
                         if callback(locals(), globals()) == False:
                             break
-                    if total_timesteps and timesteps_so_far >= total_timesteps:
+                    if total_timesteps and timesteps_so_far() >= total_timesteps:
                         break
 
                     logger.log("********** Iteration %i ************" % iters_so_far)
@@ -315,7 +321,7 @@ class TRPO(ActorCriticRLModel):
                                                                               seg["true_rew"].reshape(
                                                                                   (self.n_envs, -1)),
                                                                               seg["dones"].reshape((self.n_envs, -1)),
-                                                                              writer, timesteps_so_far)
+                                                                              writer, timesteps_so_far())
 
                         args = seg["ob"], seg["ob"], seg["ac"], atarg
                         fvpargs = [arr[::5] for arr in args]
@@ -323,7 +329,7 @@ class TRPO(ActorCriticRLModel):
                         self.assign_old_eq_new(sess=self.sess)
 
                         with self.timed("computegrad"):
-                            steps = timesteps_so_far + (k + 1) * (seg["total_timestep"] / self.g_step)
+                            steps = timesteps_so_far() + (k + 1) * (seg["total_timestep"] / self.g_step)
                             run_options = tf.RunOptions(trace_level=tf.RunOptions.FULL_TRACE)
                             run_metadata = tf.RunMetadata()
                             # run loss backprop with summary, and save the metadata (memory, compute time, ...)
@@ -429,13 +435,17 @@ class TRPO(ActorCriticRLModel):
                     logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     if self.using_gail:
                         logger.record_tabular("EpTrueRewMean", np.mean(true_rewbuffer))
-                    logger.record_tabular("EpThisIter", len(lens))
-                    episodes_so_far += len(lens)
-                    timesteps_so_far += seg["total_timestep"]
+                    # count number of episodes done this iteration
+                    ep_done = (MPI.COMM_WORLD.allreduce(seg["dones"]) == True).sum()
+                    logger.record_tabular("EpThisIter", ep_done)
+                    # total timesteps between 2 resets
+                    total_timestep = MPI.COMM_WORLD.allreduce(seg["total_timestep"])
+                    logger.record_tabular("TimestepsSoFar", timesteps_so_far())
+                    if ep_done > 0:
+                        episodes_so_far += ep_done
+                        prev_timesteps_so_far = prev_timesteps_so_far + total_timestep
                     iters_so_far += 1
-
                     logger.record_tabular("EpisodesSoFar", episodes_so_far)
-                    logger.record_tabular("TimestepsSoFar", timesteps_so_far)
                     logger.record_tabular("TimeElapsed", time.time() - t_start)
 
                     if self.verbose >= 1 and self.rank == 0:

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -427,7 +427,6 @@ class TRPO(ActorCriticRLModel):
 
                     if len(lenbuffer) > 0:
                         logger.record_tabular("EpLenMean", np.mean(lenbuffer))
-                    if len(rewbuffer) > 0:
                         logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     if self.using_gail:
                         logger.record_tabular("EpTrueRewMean", np.mean(true_rewbuffer))

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -262,6 +262,8 @@ class TRPO(ActorCriticRLModel):
                 prev_timesteps_so_far = 0
                 # timesteps count after last reset
                 total_timestep = 0
+                # number of episodes done in an iteration
+                ep_done = 0
                 # current total count of timesteps
                 def timesteps_so_far():
                     return prev_timesteps_so_far + total_timestep
@@ -431,6 +433,10 @@ class TRPO(ActorCriticRLModel):
                     lenbuffer.extend(lens)
                     rewbuffer.extend(rews)
 
+                    # update global timesteps count only when both losses 
+                    # and timesteps so far metrics are recorded
+                    if ep_done > 0:
+                        prev_timesteps_so_far += total_timestep
                     logger.record_tabular("EpLenMean", np.mean(lenbuffer))
                     logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     if self.using_gail:
@@ -443,7 +449,6 @@ class TRPO(ActorCriticRLModel):
                     logger.record_tabular("TimestepsSoFar", timesteps_so_far())
                     if ep_done > 0:
                         episodes_so_far += ep_done
-                        prev_timesteps_so_far += total_timestep
                     iters_so_far += 1
                     logger.record_tabular("EpisodesSoFar", episodes_so_far)
                     logger.record_tabular("TimeElapsed", time.time() - t_start)

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -425,8 +425,10 @@ class TRPO(ActorCriticRLModel):
                     lenbuffer.extend(lens)
                     rewbuffer.extend(rews)
 
-                    logger.record_tabular("EpLenMean", np.mean(lenbuffer))
-                    logger.record_tabular("EpRewMean", np.mean(rewbuffer))
+                    if len(lenbuffer) > 0:
+                        logger.record_tabular("EpLenMean", np.mean(lenbuffer))
+                    if len(rewbuffer) > 0:
+                        logger.record_tabular("EpRewMean", np.mean(rewbuffer))
                     if self.using_gail:
                         logger.record_tabular("EpTrueRewMean", np.mean(true_rewbuffer))
                     logger.record_tabular("EpThisIter", len(lens))

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -443,7 +443,7 @@ class TRPO(ActorCriticRLModel):
                     logger.record_tabular("TimestepsSoFar", timesteps_so_far())
                     if ep_done > 0:
                         episodes_so_far += ep_done
-                        prev_timesteps_so_far = prev_timesteps_so_far + total_timestep
+                        prev_timesteps_so_far += total_timestep
                     iters_so_far += 1
                     logger.record_tabular("EpisodesSoFar", episodes_so_far)
                     logger.record_tabular("TimeElapsed", time.time() - t_start)

--- a/stable_baselines/trpo_mpi/utils.py
+++ b/stable_baselines/trpo_mpi/utils.py
@@ -78,6 +78,8 @@ def traj_segment_generator(policy, env, horizon, reward_giver=None, gail=False):
             ep_rets = []
             ep_true_rets = []
             ep_lens = []
+            # make sure total_timesteps increments correctly
+            cur_ep_len = 0
         i = step % horizon
         observations[i] = observation
         vpreds[i] = vpred[0]

--- a/stable_baselines/trpo_mpi/utils.py
+++ b/stable_baselines/trpo_mpi/utils.py
@@ -36,7 +36,7 @@ def traj_segment_generator(policy, env, horizon, reward_giver=None, gail=False):
     observation = env.reset()
 
     cur_ep_ret = 0  # return in current episode
-    cur_ep_len = 0  # len of current episode
+    current_it_len = 0  # len of current iteration
     cur_ep_true_ret = 0
     ep_true_rets = []
     ep_rets = []  # returns of completed episodes in this segment
@@ -62,24 +62,21 @@ def traj_segment_generator(policy, env, horizon, reward_giver=None, gail=False):
         if step > 0 and step % horizon == 0:
             # Fix to avoid "mean of empty slice" warning when there is only one episode
             if len(ep_rets) == 0:
-                ep_rets = [cur_ep_ret]
-                ep_lens = [cur_ep_len]
-                ep_true_rets = [cur_ep_true_ret]
-                total_timesteps = cur_ep_len
+                current_it_timesteps = current_it_len
             else:
-                total_timesteps = sum(ep_lens) + cur_ep_len
+                current_it_timesteps = sum(ep_lens) + current_it_len
 
             yield {"ob": observations, "rew": rews, "dones": dones, "true_rew": true_rews, "vpred": vpreds,
                    "ac": actions, "prevac": prev_actions, "nextvpred": vpred * (1 - new), "ep_rets": ep_rets,
-                   "ep_lens": ep_lens, "ep_true_rets": ep_true_rets, "total_timestep": total_timesteps}
+                   "ep_lens": ep_lens, "ep_true_rets": ep_true_rets, "total_timestep": current_it_timesteps}
             _, vpred, _, _ = policy.step(observation.reshape(-1, *observation.shape))
             # Be careful!!! if you change the downstream algorithm to aggregate
             # several of these batches, then be sure to do a deepcopy
             ep_rets = []
             ep_true_rets = []
             ep_lens = []
-            # make sure total_timesteps increments correctly
-            cur_ep_len = 0
+            # make sure current_it_timesteps increments correctly
+            current_it_len = 0
         i = step % horizon
         observations[i] = observation
         vpreds[i] = vpred[0]
@@ -103,14 +100,14 @@ def traj_segment_generator(policy, env, horizon, reward_giver=None, gail=False):
 
         cur_ep_ret += rew
         cur_ep_true_ret += true_rew
-        cur_ep_len += 1
+        current_it_len += 1
         if done:
             ep_rets.append(cur_ep_ret)
             ep_true_rets.append(cur_ep_true_ret)
-            ep_lens.append(cur_ep_len)
+            ep_lens.append(current_it_len)
             cur_ep_ret = 0
             cur_ep_true_ret = 0
-            cur_ep_len = 0
+            current_it_len = 0
             if not isinstance(env, VecEnv):
                 observation = env.reset()
         step += 1


### PR DESCRIPTION
fix for #164 which is about TimestepsSoFar computation in TRPO, but I also took the opportunity to fix EpThisIter and EpisodesSoFar that were not reflecting reality. I think this went under radar because episode length is lesser than batch size for some environments. 

Also, I applied the same fix for PPO1. Didn't check for other algos. 

Tested on several classic environments, custom environment with episode length >> batch size, with and without MPI.

Fixes #164 