### PR TITLE
Dict space support for VecEnv

### DIFF
--- a/docs/guide/algos.rst
+++ b/docs/guide/algos.rst
@@ -37,6 +37,7 @@ TRPO         ✔️                        ✔️         ✔️           ✔�
 .. [#f4] Multi Processing with `MPI`_.
 .. [#f5] TODO, in project scope.
 
+Note non-array spaces such as `Dict` or `Tuple` are not currently supported by any algorithm.
 
 Actions ``gym.spaces``:
 

--- a/docs/guide/algos.rst
+++ b/docs/guide/algos.rst
@@ -37,7 +37,8 @@ TRPO         ✔️                        ✔️         ✔️           ✔�
 .. [#f4] Multi Processing with `MPI`_.
 .. [#f5] TODO, in project scope.
 
-Note non-array spaces such as `Dict` or `Tuple` are not currently supported by any algorithm.
+.. note::
+    Non-array spaces such as `Dict` or `Tuple` are not currently supported by any algorithm.
 
 Actions ``gym.spaces``:
 

--- a/docs/guide/vec_envs.rst
+++ b/docs/guide/vec_envs.rst
@@ -12,12 +12,12 @@ It is the same for `observations`, `rewards` and end of episode signals (`dones`
 In the case of non-array observation spaces such as `Dict` or `Tuple`, where different sub-spaces
 may have different shapes, the sub-observations are vectors (of dimension `n`).
 
-============= ============== ======= ============ ======== ========= ================
-Name          Refactored     ``Box`` ``Discrete`` ``Dict`` ``Tuple`` Multi Processing
-============= ============== ======= ============ ======== ========= ================
-DummyVecEnv   ✔️              ✔️      ✔️            ✔️       ✔️         ❌️
-SubprocVecEnv ✔️              ✔️      ✔️            ✔️       ✔️         ✔️
-============= ============== ======= ============ ======== ========= ================
+============= ======= ============ ======== ========= ================
+Name          ``Box`` ``Discrete`` ``Dict`` ``Tuple`` Multi Processing
+============= ======= ============ ======== ========= ================
+DummyVecEnv   ✔️       ✔️           ✔️        ✔️         ❌️
+SubprocVecEnv ✔️       ✔️           ✔️        ✔️         ✔️
+============= ======= ============ ======== ========= ================
 
 .. note::
 

--- a/docs/guide/vec_envs.rst
+++ b/docs/guide/vec_envs.rst
@@ -5,11 +5,19 @@
 Vectorized Environments
 =======================
 
-Vectorized Environments are a way to multiprocess training. Instead of training a RL agent
-on 1 environment, it allows to train it on `n` environments using `n` processes.
-Because of that, `actions` passed to the environment are now a vector (of dimension `n`). It is the same for `observations`,
-`rewards` and end of episode signals (`dones`).
+Vectorized Environments are a method for multiprocess training. Instead of training an RL agent
+on 1 environment, it allows us to train it on `n` environments using `n` processes.
+Because of this, `actions` passed to the environment are now a vector (of dimension `n`).
+It is the same for `observations`, `rewards` and end of episode signals (`dones`).
+In the case of non-array observation spaces such as `Dict` or `Tuple`, where different sub-spaces
+may have different shapes, the sub-observations are vectors (of dimension `n`).
 
+============= ============== ======= ============ ======== ========= ================
+Name          Refactored     ``Box`` ``Discrete`` ``Dict`` ``Tuple`` Multi Processing
+============= ============== ======= ============ ======== ========= ================
+DummyVecEnv   ✔️              ✔️      ✔️            ✔️       ✔️         ❌️
+SubprocVecEnv ✔️              ✔️      ✔️            ✔️       ✔️         ✔️
+============= ============== ======= ============ ======== ========= ================
 
 .. note::
 
@@ -17,7 +25,7 @@ Because of that, `actions` passed to the environment are now a vector (of dimens
 
 .. note::
 
-	When using vectorized environments, the environments are automatically resetted at the end of each episode.
+	When using vectorized environments, the environments are automatically reset at the end of each episode.
 
 .. warning::
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -8,7 +8,7 @@ For download links, please look at `Github release page <https://github.com/hill
 Pre-release 2.4.2a (WIP)
 ------------------------
 
-- added suport for Dict spaces in DummyVecEnv and SubprocVecEnv
+- added suport for Dict spaces in DummyVecEnv and SubprocVecEnv. (@AdamGleave) 
 
 Release 2.4.1 (2019-02-11)
 --------------------------
@@ -241,4 +241,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn
+@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 For download links, please look at `Github release page <https://github.com/hill-a/stable-baselines/releases>`_.
 
+Pre-release 2.4.2a (WIP)
+------------------------
+
+- added suport for Dict spaces in DummyVecEnv and SubprocVecEnv
+
 Release 2.4.1 (2019-02-11)
 --------------------------
 

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -64,7 +64,7 @@ class DummyVecEnv(VecEnv):
                 self.buf_obs[key][env_idx] = obs[key]
 
     def _obs_from_buf(self):
-        return dict_to_obs(copy_obs_dict(self.buf_obs))
+        return dict_to_obs(self.observation_space, copy_obs_dict(self.buf_obs))
 
     def env_method(self, method_name, *method_args, **method_kwargs):
         """

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import numpy as np
 
 from stable_baselines.common.vec_env import VecEnv
@@ -18,8 +19,9 @@ class DummyVecEnv(VecEnv):
         obs_space = env.observation_space
         self.keys, shapes, dtypes = obs_space_info(obs_space)
 
-        self.buf_obs = {k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k])
-                        for k in self.keys}
+        self.buf_obs = OrderedDict([
+            (k, np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k]))
+            for k in self.keys])
         self.buf_dones = np.zeros((self.num_envs,), dtype=np.bool)
         self.buf_rews = np.zeros((self.num_envs,), dtype=np.float32)
         self.buf_infos = [{} for _ in range(self.num_envs)]

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -1,10 +1,7 @@
-from collections import OrderedDict
-
 import numpy as np
-from gym import spaces
 
-from . import VecEnv
-from .util import copy_obs_dict, dict_to_obs, obs_space_info
+from stable_baselines.common.vec_env import VecEnv
+from stable_baselines.common.vec_env.util import copy_obs_dict, dict_to_obs, obs_space_info
 
 
 class DummyVecEnv(VecEnv):
@@ -18,12 +15,11 @@ class DummyVecEnv(VecEnv):
         self.envs = [fn() for fn in env_fns]
         env = self.envs[0]
         VecEnv.__init__(self, len(env_fns), env.observation_space, env.action_space)
-        shapes, dtypes = {}, {}
-        self.keys = []
         obs_space = env.observation_space
         self.keys, shapes, dtypes = obs_space_info(obs_space)
 
-        self.buf_obs = {k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k]) for k in self.keys}
+        self.buf_obs = {k: np.zeros((self.num_envs,) + tuple(shapes[k]), dtype=dtypes[k])
+                        for k in self.keys}
         self.buf_dones = np.zeros((self.num_envs,), dtype=np.bool)
         self.buf_rews = np.zeros((self.num_envs,), dtype=np.float32)
         self.buf_infos = [{} for _ in range(self.num_envs)]

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -167,8 +167,10 @@ def _flatten_obs(obs):
     """
     Flatten observations, depending on the observation space.
 
-    :param obs: an observation, either a numpy array or a dict of numpy arrays.
-    :return a flattened numpy array or a dict of flattened numpy arrays.
+    :param obs: (dict<ndarray> or ndarray) an observation.
+                Either a numpy array or a dict of numpy arrays.
+    :return (dict<ndarray> or ndarray) a flattened numpy array
+            or a dict of flattened numpy arrays.
     """
     assert isinstance(obs, list) or isinstance(obs, tuple)
     assert len(obs) > 0

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -1,4 +1,4 @@
-import collections
+from collections import OrderedDict
 from multiprocessing import Process, Pipe
 
 import gym
@@ -170,20 +170,22 @@ def _flatten_obs(obs, space):
     """
     Flatten observations, depending on the observation space.
 
-    :param obs: (dict<ndarray>, tuple<ndarray> or ndarray) an observation.
-                Either a numpy array or a dict or tuple of numpy arrays.
-    :return (OrderedDict<ndarray>, tuple<ndarray> or ndarray) a flattened numpy array
-            or an OrderedDict or tuple of flattened numpy arrays.
+    :param obs: (list<X> or tuple<X> where X is dict<ndarray>, tuple<ndarray> or ndarray) observations.
+                A list or tuple of observations, one per environment.
+                Each environment observation may be a NumPy array, or a dict or tuple of NumPy arrays.
+    :return (OrderedDict<ndarray>, tuple<ndarray> or ndarray) flattened observations.
+            A flattened NumPy array or an OrderedDict or tuple of flattened numpy arrays.
+            Each NumPy array has the environment index as its first axis.
     """
-    assert isinstance(obs, list) or isinstance(obs, tuple)
-    assert len(obs) > 0
+    assert isinstance(obs, (list, tuple)), "expected list or tuple of observations per environment"
+    assert len(obs) > 0, "need observations from at least one environment"
 
     if isinstance(space, gym.spaces.Dict):
-        assert isinstance(obs[0], dict)
-        return collections.OrderedDict([(k, np.stack([o[k] for o in obs]))
-                                        for k in space.spaces.keys()])
+        assert isinstance(space.spaces, OrderedDict), "Dict space must have ordered subspaces"
+        assert isinstance(obs[0], dict), "non-dict observation for environment with Dict observation space"
+        return OrderedDict([(k, np.stack([o[k] for o in obs])) for k in space.spaces.keys()])
     elif isinstance(space, gym.spaces.Tuple):
-        assert isinstance(obs[0], tuple)
+        assert isinstance(obs[0], tuple), "non-tuple observation for environment with Tuple observation space"
         obs_len = len(space.spaces)
         return tuple((np.stack([o[i] for o in obs]) for i in range(obs_len)))
     else:

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -168,10 +168,10 @@ def _flatten_obs(obs):
     """
     Flatten observations, depending on the observation space.
 
-    :param obs: (dict<ndarray> or ndarray) an observation.
-                Either a numpy array or a dict of numpy arrays.
-    :return (dict<ndarray> or ndarray) a flattened numpy array
-            or a dict of flattened numpy arrays.
+    :param obs: (dict<ndarray>, tuple<ndarray> or ndarray) an observation.
+                Either a numpy array or a dict or tuple of numpy arrays.
+    :return (dict<ndarray>, tuple<ndarray> or ndarray) a flattened numpy array
+            or a dict or tuple of flattened numpy arrays.
     """
     assert isinstance(obs, list) or isinstance(obs, tuple)
     assert len(obs) > 0
@@ -180,5 +180,8 @@ def _flatten_obs(obs):
         assert isinstance(obs[0], collections.OrderedDict)
         keys = obs[0].keys()
         return {k: np.stack([o[k] for o in obs]) for k in keys}
+    elif isinstance(obs[0], tuple):
+        obs_len = len(obs[0])
+        return tuple((np.stack([o[i] for o in obs]) for i in range(obs_len)))
     else:
         return np.stack(obs)

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -1,3 +1,4 @@
+import collections
 from multiprocessing import Process, Pipe
 
 import numpy as np
@@ -176,7 +177,6 @@ def _flatten_obs(obs):
     assert len(obs) > 0
 
     if isinstance(obs[0], dict):
-        import collections
         assert isinstance(obs[0], collections.OrderedDict)
         keys = obs[0].keys()
         return {k: np.stack([o[k] for o in obs]) for k in keys}

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -164,6 +164,12 @@ class SubprocVecEnv(VecEnv):
 
 
 def _flatten_obs(obs):
+    """
+    Flatten observations, depending on the observation space.
+
+    :param obs: an observation, either a numpy array or a dict of numpy arrays.
+    :return a flattened numpy array or a dict of flattened numpy arrays.
+    """
     assert isinstance(obs, list) or isinstance(obs, tuple)
     assert len(obs) > 0
 

--- a/stable_baselines/common/vec_env/util.py
+++ b/stable_baselines/common/vec_env/util.py
@@ -1,0 +1,59 @@
+"""
+Helpers for dealing with vectorized environments.
+"""
+
+from collections import OrderedDict
+
+import gym
+import numpy as np
+
+
+def copy_obs_dict(obs):
+    """
+    Deep-copy an observation dict.
+    """
+    return {k: np.copy(v) for k, v in obs.items()}
+
+
+def dict_to_obs(obs_dict):
+    """
+    Convert an observation dict into a raw array if the
+    original observation space was not a Dict space.
+    """
+    if set(obs_dict.keys()) == {None}:
+        return obs_dict[None]
+    return obs_dict
+
+
+def obs_space_info(obs_space):
+    """
+    Get dict-structured information about a gym.Space.
+
+    Returns:
+      A tuple (keys, shapes, dtypes):
+        keys: a list of dict keys.
+        shapes: a dict mapping keys to shapes.
+        dtypes: a dict mapping keys to dtypes.
+    """
+    if isinstance(obs_space, gym.spaces.Dict):
+        assert isinstance(obs_space.spaces, OrderedDict)
+        subspaces = obs_space.spaces
+    else:
+        subspaces = {None: obs_space}
+    keys = []
+    shapes = {}
+    dtypes = {}
+    for key, box in subspaces.items():
+        keys.append(key)
+        shapes[key] = box.shape
+        dtypes[key] = box.dtype
+    return keys, shapes, dtypes
+
+
+def obs_to_dict(obs):
+    """
+    Convert an observation into a dict.
+    """
+    if isinstance(obs, dict):
+        return obs
+    return {None: obs}

--- a/stable_baselines/common/vec_env/util.py
+++ b/stable_baselines/common/vec_env/util.py
@@ -12,8 +12,8 @@ def copy_obs_dict(obs):
     """
     Deep-copy a dict of numpy arrays.
 
-    :param obs (dict<ndarray>): a dict of numpy arrays.
-    :return a dict of copied numpy arrays.
+    :param obs: (dict<ndarray>): a dict of numpy arrays.
+    :return (dict<ndarray>) a dict of copied numpy arrays.
     """
     return {k: np.copy(v) for k, v in obs.items()}
 
@@ -22,9 +22,9 @@ def obs_to_dict(obs):
     """
     Convert an observation into a dict.
 
-    :param obs (gym.spaces.Space): an observation space.
-    :return if obs was a dictionary, returns the dictionary. Otherwise, returns
-            a dictionary with a single key None and value obs.
+    :param obs: (gym.spaces.Space) an observation space.
+    :return: (dict<ndarray>) if obs was a dictionary, returns obs.
+             Otherwise, returns a dictionary with a single key None and value obs.
     """
     if isinstance(obs, dict):
         return obs
@@ -35,9 +35,9 @@ def dict_to_obs(obs_dict):
     """
     Convert an observation dict into a raw array if singleton.
 
-    :param obs_dict (dict<ndarray>): a dict of numpy arrays.
-    :return if obs_dict has a single element with key None, returns that value.
-            Otherwise, returns the original dict.
+    :param obs_dict: (dict<ndarray>) a dict of numpy arrays.
+    :return (ndarray or dict<ndarray>): if obs_dict has a single element
+            with key None, returns that value. Otherwise, returns the original dict.
     """
     if set(obs_dict.keys()) == {None}:
         return obs_dict[None]
@@ -48,8 +48,8 @@ def obs_space_info(obs_space):
     """
     Get dict-structured information about a gym.Space.
 
-    :param obs_space (gym.spaces.Space): an observation space
-    :return A tuple (keys, shapes, dtypes):
+    :param obs_space: (gym.spaces.Space) an observation space
+    :return (tuple) A tuple (keys, shapes, dtypes):
         keys: a list of dict keys.
         shapes: a dict mapping keys to shapes.
         dtypes: a dict mapping keys to dtypes.

--- a/stable_baselines/common/vec_env/util.py
+++ b/stable_baselines/common/vec_env/util.py
@@ -10,15 +10,34 @@ import numpy as np
 
 def copy_obs_dict(obs):
     """
-    Deep-copy an observation dict.
+    Deep-copy a dict of numpy arrays.
+
+    :param obs (dict<ndarray>): a dict of numpy arrays.
+    :return a dict of copied numpy arrays.
     """
     return {k: np.copy(v) for k, v in obs.items()}
 
 
+def obs_to_dict(obs):
+    """
+    Convert an observation into a dict.
+
+    :param obs (gym.spaces.Space): an observation space.
+    :return if obs was a dictionary, returns the dictionary. Otherwise, returns
+            a dictionary with a single key None and value obs.
+    """
+    if isinstance(obs, dict):
+        return obs
+    return {None: obs}
+
+
 def dict_to_obs(obs_dict):
     """
-    Convert an observation dict into a raw array if the
-    original observation space was not a Dict space.
+    Convert an observation dict into a raw array if singleton.
+
+    :param obs_dict (dict<ndarray>): a dict of numpy arrays.
+    :return if obs_dict has a single element with key None, returns that value.
+            Otherwise, returns the original dict.
     """
     if set(obs_dict.keys()) == {None}:
         return obs_dict[None]
@@ -29,8 +48,8 @@ def obs_space_info(obs_space):
     """
     Get dict-structured information about a gym.Space.
 
-    Returns:
-      A tuple (keys, shapes, dtypes):
+    :param obs_space (gym.spaces.Space): an observation space
+    :return A tuple (keys, shapes, dtypes):
         keys: a list of dict keys.
         shapes: a dict mapping keys to shapes.
         dtypes: a dict mapping keys to dtypes.
@@ -48,12 +67,3 @@ def obs_space_info(obs_space):
         shapes[key] = box.shape
         dtypes[key] = box.dtype
     return keys, shapes, dtypes
-
-
-def obs_to_dict(obs):
-    """
-    Convert an observation into a dict.
-    """
-    if isinstance(obs, dict):
-        return obs
-    return {None: obs}

--- a/stable_baselines/common/vec_env/util.py
+++ b/stable_baselines/common/vec_env/util.py
@@ -15,7 +15,7 @@ def copy_obs_dict(obs):
     :param obs: (OrderedDict<ndarray>): a dict of numpy arrays.
     :return (OrderedDict<ndarray>) a dict of copied numpy arrays.
     """
-    assert isinstance(obs, OrderedDict)
+    assert isinstance(obs, OrderedDict), "unexpected type for observations '{}'".format(type(obs))
     return OrderedDict([(k, np.copy(v)) for k, v in obs.items()])
 
 
@@ -34,10 +34,10 @@ def dict_to_obs(space, obs_dict):
     if isinstance(space, gym.spaces.Dict):
         return obs_dict
     elif isinstance(space, gym.spaces.Tuple):
-        assert len(obs_dict) == len(space.spaces)
+        assert len(obs_dict) == len(space.spaces), "size of observation does not match size of observation space"
         return tuple((obs_dict[i] for i in range(len(space.spaces))))
     else:
-        assert set(obs_dict.keys()) == {None}
+        assert set(obs_dict.keys()) == {None}, "multiple observation keys for unstructured observation space"
         return obs_dict[None]
 
 
@@ -56,12 +56,12 @@ def obs_space_info(obs_space):
         dtypes: a dict mapping keys to dtypes.
     """
     if isinstance(obs_space, gym.spaces.Dict):
-        assert isinstance(obs_space.spaces, OrderedDict)
+        assert isinstance(obs_space.spaces, OrderedDict), "Dict space must have ordered subspaces"
         subspaces = obs_space.spaces
     elif isinstance(obs_space, gym.spaces.Tuple):
         subspaces = {i: space for i, space in enumerate(obs_space.spaces)}
     else:
-        assert not hasattr(obs_space, 'spaces')
+        assert not hasattr(obs_space, 'spaces'), "Unsupported structured space '{}'".format(type(obs_space))
         subspaces = {None: obs_space}
     keys = []
     shapes = {}

--- a/stable_baselines/common/vec_env/util.py
+++ b/stable_baselines/common/vec_env/util.py
@@ -12,10 +12,11 @@ def copy_obs_dict(obs):
     """
     Deep-copy a dict of numpy arrays.
 
-    :param obs: (dict<ndarray>): a dict of numpy arrays.
-    :return (dict<ndarray>) a dict of copied numpy arrays.
+    :param obs: (OrderedDict<ndarray>): a dict of numpy arrays.
+    :return (OrderedDict<ndarray>) a dict of copied numpy arrays.
     """
-    return {k: np.copy(v) for k, v in obs.items()}
+    assert isinstance(obs, OrderedDict)
+    return OrderedDict([(k, np.copy(v)) for k, v in obs.items()])
 
 
 def dict_to_obs(space, obs_dict):
@@ -24,7 +25,7 @@ def dict_to_obs(space, obs_dict):
     specified by space.
 
     :param space: (gym.spaces.Space) an observation space.
-    :param obs_dict: (dict<ndarray>) a dict of numpy arrays.
+    :param obs_dict: (OrderedDict<ndarray>) a dict of numpy arrays.
     :return (ndarray, tuple<ndarray> or dict<ndarray>): returns an observation
             of the same type as space. If space is Dict, function is identity;
             if space is Tuple, converts dict to Tuple; otherwise, space is

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -103,18 +103,18 @@ def test_vecenv_dict_space(vec_env_class):
     def make_env():
         return CustomGymEnv(space)
 
-    def check_ob(ob):
-        assert isinstance(ob, dict)
-        for k, values in ob.items():
-            for v in values:
-                assert space.spaces[k].contains(v)
+    def check_obs(obs):
+        assert isinstance(obs, dict)
+        for key, values in obs.items():
+            for value in values:
+                assert space.spaces[key].contains(value)
 
     vec_env = vec_env_class([make_env for _ in range(N_ENVS)])
-    ob = vec_env.reset()
-    check_ob(ob)
+    obs = vec_env.reset()
+    check_obs(obs)
 
     dones = [False] * N_ENVS
     while not any(dones):
         actions = [vec_env.action_space.sample() for _ in range(N_ENVS)]
-        ob, rews, dones, infos = vec_env.step(actions)
-        check_ob(ob)
+        obs, _rews, dones, _infos = vec_env.step(actions)
+        check_obs(obs)


### PR DESCRIPTION
OpenAI added support for Dict observation spaces to DummyVecEnv and SubprocVecEnv after the fork. This PR cherry-picks these changes, while retaining the improvements made by Stable Baselines. This will be needed (amongst other changes) to support use cases such as #133.

OpenAI also added ShmemVecEnv, with common code factored out into util.py. I've retained the util.py as a separate file in case we wish to also port over ShmemVecEnv in the future.