### PR TITLE
Make SubprocVecEnv Thread Safe

### DIFF
--- a/docs/guide/vec_envs.rst
+++ b/docs/guide/vec_envs.rst
@@ -21,10 +21,9 @@ Because of that, `actions` passed to the environment are now a vector (of dimens
 
 .. warning::
 
-		When using ``SubprocVecEnv``, Windows users must wrap the code
-		in an ``if __name__=="__main__":``.
-		See `stackoverflow question <https://stackoverflow.com/questions/24374288/where-to-put-freeze-support-in-a-python-script>`_
-		for more information about multiprocessing on Windows using python.
+		When using ``SubprocVecEnv``, users must wrap the code in an ``if __name__ == "__main__":``
+                if using the ``forkserver`` or ``spawn`` start method (the default).  For more information, see Python's 
+                `multiprocessing guidelines <https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods>`_.
 
 
 DummyVecEnv

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -8,7 +8,7 @@ For download links, please look at `Github release page <https://github.com/hill
 Pre-release 2.4.2a (WIP)
 ------------------------
 
-- added suport for Dict spaces in DummyVecEnv and SubprocVecEnv. (@AdamGleave) 
+- added support for Dict spaces in DummyVecEnv and SubprocVecEnv. (@AdamGleave) 
 - made SubprocVecEnv thread-safe by default; support arbitrary multiprocessing start methods. (@AdamGleave)
 
 Release 2.4.1 (2019-02-11)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -5,6 +5,11 @@ Changelog
 
 For download links, please look at `Github release page <https://github.com/hill-a/stable-baselines/releases>`_.
 
+Pre-release 2.4.2a (WIP)
+------------------------
+
+- made SubprocVecEnv thread-safe by default; support arbitrary multiprocessing start methods. (@AdamGleave)
+
 Release 2.4.1 (2019-02-11)
 --------------------------
 
@@ -236,4 +241,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn
+@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -1,7 +1,5 @@
-from collections import OrderedDict
 import multiprocessing
 
-import gym
 import numpy as np
 
 from stable_baselines.common.vec_env import VecEnv, CloudpickleWrapper

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -177,7 +177,7 @@ def test_vecenv_tuple_spaces(vec_env_class):
     return check_vecenv_spaces(vec_env_class, space, obs_assert)
 
 
-def test_subproc_vecenv_start_method():
+def test_subproc_start_method():
     start_methods = [None] + multiprocessing.get_all_start_methods()
     space = gym.spaces.Discrete(2)
 

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -1,5 +1,7 @@
 import collections
+import functools
 import itertools
+import multiprocessing
 import pytest
 import gym
 import numpy as np
@@ -170,3 +172,19 @@ def test_vecenv_tuple_spaces(vec_env_class):
             check_vecenv_obs(values, inner_space)
 
     return check_vecenv_spaces(vec_env_class, space, obs_assert)
+
+
+def test_subproc_vecenv_start_method():
+    start_methods = [None] + multiprocessing.get_all_start_methods()
+    space = gym.spaces.Discrete(2)
+
+    def obs_assert(obs):
+        return check_vecenv_obs(obs, space)
+
+    for start_method in start_methods:
+        vec_env_class = functools.partial(SubprocVecEnv, start_method=start_method)
+        check_vecenv_spaces(vec_env_class, space, obs_assert)
+
+    with pytest.raises(ValueError, match="cannot find context for 'illegal_method'"):
+        vec_env_class = functools.partial(SubprocVecEnv, start_method='illegal_method')
+        check_vecenv_spaces(vec_env_class, space, obs_assert)

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -96,6 +96,8 @@ def test_vecenv_custom_calls(vec_env_class):
     assert setattr_result == [None for _ in range(2)]
     assert getattr_result == [12] + [0 for _ in range(N_ENVS - 2)] + [12]
 
+    vec_env.close()
+
 
 SPACES = collections.OrderedDict([
     ('discrete', gym.spaces.Discrete(2)),
@@ -118,6 +120,7 @@ def check_vecenv_spaces(vec_env_class, space, obs_assert):
         actions = [vec_env.action_space.sample() for _ in range(N_ENVS)]
         obs, _rews, dones, _infos = vec_env.step(actions)
         obs_assert(obs)
+    vec_env.close()
 
 
 def check_vecenv_obs(obs, space):


### PR DESCRIPTION
As discussed in issue #217, `SubprocVecEnv` uses on Unix systems the non-thread-safe `fork` method of multiprocessing, which can cause issues e.g. when the parent process has an extant TensorFlow session. This PR changes `SubprocVecEnv` to use the thread-safe `spawn` method.