### PR TITLE
Fixed DDPG normalization of obs and returns

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -20,6 +20,7 @@ Release 2.4.1 (2019-02-11)
 - remove gym spaces patch for equality functions
 - fixed tensorflow dependency: cpu version was installed overwritting tensorflow-gpu when present.
 - fixed a bug in ``traj_segment_generator`` (used in ppo1 and trpo) where ``new`` was not updated. (spotted by @junhyeokahn)
+- fixed bug in saving and loading ddpg model when using normalization of obs or returns
 
 
 Release 2.4.0 (2019-01-17)
@@ -236,4 +237,4 @@ Contributors (since v2.0.0):
 In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
-@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn
+@EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @tperol

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -8,9 +8,10 @@ For download links, please look at `Github release page <https://github.com/hill
 Pre-release 2.4.2a (WIP)
 ------------------------
 
-- added support for Dict spaces in DummyVecEnv and SubprocVecEnv. (@AdamGleave) 
+- added support for Dict spaces in DummyVecEnv and SubprocVecEnv. (@AdamGleave)
 - made SubprocVecEnv thread-safe by default; support arbitrary multiprocessing start methods. (@AdamGleave)
 - fixed bug in saving and loading ddpg model when using normalization of obs or returns (@tperol)
+- changed DDPG default buffer size from 100 to 50000.
 
 
 Release 2.4.1 (2019-02-11)

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -177,7 +177,7 @@ class DDPG(OffPolicyRLModel):
                  normalize_observations=False, tau=0.001, batch_size=128, param_noise_adaption_interval=50,
                  normalize_returns=False, enable_popart=False, observation_range=(-5., 5.), critic_l2_reg=0.,
                  return_range=(-np.inf, np.inf), actor_lr=1e-4, critic_lr=1e-3, clip_norm=None, reward_scale=1.,
-                 render=False, render_eval=False, memory_limit=100, verbose=0, tensorboard_log=None,
+                 render=False, render_eval=False, memory_limit=50000, verbose=0, tensorboard_log=None,
                  _init_setup_model=True, policy_kwargs=None, full_tensorboard_log=False):
 
         # TODO: replay_buffer refactoring

--- a/tests/test_continuous.py
+++ b/tests/test_continuous.py
@@ -15,6 +15,7 @@ from stable_baselines.trpo_mpi import TRPO
 from stable_baselines.common import set_global_seeds
 from stable_baselines.common.vec_env import DummyVecEnv
 from stable_baselines.common.identity_env import IdentityEnvBox
+from stable_baselines.ddpg import AdaptiveParamNoiseSpec
 from tests.test_common import _assert_eq
 
 
@@ -148,7 +149,34 @@ def test_model_manipulation(model_class):
 
 
 def test_ddpg():
-    args = ['--env-id', 'Pendulum-v0', '--num-timesteps', 1000]
+    args = ['--env-id', 'Pendulum-v0', '--num-timesteps', 1000, '--noise-type', 'ou_0.01']
     args = list(map(str, args))
     return_code = subprocess.call(['python', '-m', 'stable_baselines.ddpg.main'] + args)
     _assert_eq(return_code, 0)
+
+
+def test_ddpg_normalization():
+    """
+    Test that observations and returns normalizations are properly saved and loaded.
+    """
+    param_noise = AdaptiveParamNoiseSpec(initial_stddev=0.05, desired_action_stddev=0.05)
+    model = DDPG('MlpPolicy', 'Pendulum-v0', memory_limit=50000, normalize_observations=True,
+                 normalize_returns=True, nb_rollout_steps=128, nb_train_steps=1,
+                 batch_size=64, param_noise=param_noise)
+    model.learn(1000)
+    obs_rms_params = model.sess.run(model.obs_rms_params)
+    ret_rms_params = model.sess.run(model.ret_rms_params)
+    model.save('./test_ddpg')
+
+    loaded_model = DDPG.load("test_ddpg")
+    obs_rms_params_2 = loaded_model.sess.run(loaded_model.obs_rms_params)
+    ret_rms_params_2 = loaded_model.sess.run(loaded_model.ret_rms_params)
+
+    for param, param_loaded in zip(obs_rms_params + ret_rms_params,
+                                   obs_rms_params_2 + ret_rms_params_2):
+        assert np.allclose(param, param_loaded)
+
+    del model, loaded_model
+
+    if os.path.exists("./test_ddpg"):
+        os.remove("./test_ddpg")


### PR DESCRIPTION
Fixed issue #228: saving and loading a ddpg agent that uses normalized obs or returns.

Closes #228 