### PR TITLE
Record expert multi env lstm

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -9,6 +9,7 @@ Pre-Release 2.5.1a0 (WIP)
 --------------------------
 
 - doc update (fix example of result plotter + improve doc)
+- fixed logger issues when stdout lacks ``read`` function
 
 
 Release 2.5.0 (2019-03-28)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -12,8 +12,6 @@ Pre-Release 2.5.1a0 (WIP)
 - fixed logger issues when stdout lacks ``read`` function
 - added support for multi env recording to ``generate_expert_traj`` (@XMaster96)
 - added support for LSTM model recording to ``generate_expert_traj`` (@XMaster96)
-- added ``get_attr()``, ``env_method()`` and ``set_attr()`` methods for all VecEnv. Those
-  methods now all accept ``indices`` keyword to select a subset of envs. 
 - ``GAIL``: remove mandatory matplotlib dependency and refactor as subclass of ``TRPO`` (@kantneel and @AdamGleave)
 - added ``get_attr()``, ``env_method()`` and ``set_attr()`` methods for all VecEnv. 
   Those methods now all accept ``indices`` keyword to select a subset of envs.

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -10,6 +10,8 @@ Pre-Release 2.5.1a0 (WIP)
 
 - doc update (fix example of result plotter + improve doc)
 - fixed logger issues when stdout lacks ``read`` function
+- added support for multi env recording to ``generate_expert_traj`` (@XMaster96)
+- added support for LSTM model recording to ``generate_expert_traj`` (@XMaster96)
 
 
 Release 2.5.0 (2019-03-28)
@@ -272,3 +274,4 @@ In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
 @EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave @keshaviyengar @tperol
+@XMaster96

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -114,11 +114,14 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
 
         # Use only first env
         if is_vec_env:
+            if isinstance(reward, float):
+                mask = [reward for _ in range(env.num_envs)]
 
-            mask = [reward[0] for _ in range(env.num_envs)]
-            action = np.array([action[0]])
-            reward = np.array([reward[0]])
-            done = np.array([done[0]])
+            else:
+                mask = [reward[0] for _ in range(env.num_envs)]
+                action = np.array([action[0]])
+                reward = np.array([reward[0]])
+                done = np.array([done[0]])
 
         actions.append(action)
         rewards.append(reward)
@@ -126,11 +129,7 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
         reward_sum += reward
         idx += 1
         if done:
-
-            if is_vec_env:
-                if env.num_envs == 1:
-                    obs = env.reset()
-            else:
+            if not is_vec_env:
                 obs = env.reset()
 
             episode_returns[ep_idx] = reward_sum

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -116,7 +116,10 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
 
         # Use only first env
         if is_vec_env:
-            if not isinstance(reward, float):
+            if isinstance(reward, float):
+                mask = [reward for _ in range(env.num_envs)]
+            else:
+                mask = [reward[0] for _ in range(env.num_envs)]
                 action = np.array([action[0]])
                 reward = np.array([reward[0]])
                 done = np.array([done[0]])

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -9,7 +9,8 @@ from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.vec_env import VecEnv, VecFrameStack
 
 
-def generate_expert_traj(model, save_path, env=None, n_timesteps=0, n_episodes=100, image_folder='recorded_images'):
+def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
+                         n_episodes=100, image_folder='recorded_images'):
     """
     Train expert controller (if needed) and record expert trajectories.
 

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -117,16 +117,12 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
         # Use only first env
         if is_vec_env:
             if isinstance(reward, float):
-                mask = [reward for _ in range(env.num_envs)]
+                mask = [done for _ in range(env.num_envs)]
             else:
-                mask = [reward[0] for _ in range(env.num_envs)]
+                mask = [done[0] for _ in range(env.num_envs)]
                 action = np.array([action[0]])
                 reward = np.array([reward[0]])
                 done = np.array([done[0]])
-
-        # Set mask with the done value.
-        if is_vec_env:
-            mask = [done for _ in range(env.num_envs)]
 
         actions.append(action)
         rewards.append(reward)

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -104,7 +104,7 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
             observations.append(obs)
 
         if isinstance(model, BaseRLModel):
-            action, _ = model.predict(obs, state=state)
+            action, state = model.predict(obs, state=state)
         else:
             action = model(obs)
 

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -7,6 +7,7 @@ from gym import spaces
 
 from stable_baselines.common.base_class import BaseRLModel
 from stable_baselines.common.vec_env import VecEnv, VecFrameStack
+from stable_baselines.common.base_class import _UnvecWrapper
 
 
 def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
@@ -36,7 +37,7 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
     assert env is not None, "You must set the env in the model or pass it to the function."
 
     is_vec_env = False
-    if isinstance(env, VecEnv):
+    if isinstance(env, VecEnv) and not isinstance(env, _UnvecWrapper):
         is_vec_env = True
         if env.num_envs > 1:
             warnings.warn("You are using multiple envs, only the data from the first one will be recorded.")
@@ -116,13 +117,10 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
 
         # Use only first env
         if is_vec_env:
-            if isinstance(reward, float):
-                mask = [done for _ in range(env.num_envs)]
-            else:
-                mask = [done[0] for _ in range(env.num_envs)]
-                action = np.array([action[0]])
-                reward = np.array([reward[0]])
-                done = np.array([done[0]])
+            mask = [done[0] for _ in range(env.num_envs)]
+            action = np.array([action[0]])
+            reward = np.array([reward[0]])
+            done = np.array([done[0]])
 
         actions.append(action)
         rewards.append(reward)

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -89,8 +89,8 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
     episode_starts.append(True)
     reward_sum = 0.0
     idx = 0
-    state = None
-    mask = None
+    # state and mask for recurrent policies
+    state, mask = None, None
 
     if is_vec_env:
         mask = [True for _ in range(env.num_envs)]
@@ -130,6 +130,8 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
         if done:
             if not is_vec_env:
                 obs = env.reset()
+                # Reset the state in case of a recurrent policy
+                state = None
 
             episode_returns[ep_idx] = reward_sum
             reward_sum = 0.0

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -32,6 +32,8 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
     # Retrieve the environment using the RL model
     if env is None and isinstance(model, BaseRLModel):
         env = model.get_env()
+        if env.num_envs > 1:
+            warnings.warn("You are using multiple envs, only the data from the first one will be recorded.")
 
     assert env is not None, "You must set the env in the model or pass it to the function."
 

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -160,3 +160,5 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
         print(key, val.shape)
 
     np.savez(save_path, **numpy_dict)
+
+    env.close()

--- a/stable_baselines/gail/dataset/record_expert.py
+++ b/stable_baselines/gail/dataset/record_expert.py
@@ -32,14 +32,14 @@ def generate_expert_traj(model, save_path, env=None, n_timesteps=0,
     # Retrieve the environment using the RL model
     if env is None and isinstance(model, BaseRLModel):
         env = model.get_env()
-        if env.num_envs > 1:
-            warnings.warn("You are using multiple envs, only the data from the first one will be recorded.")
 
     assert env is not None, "You must set the env in the model or pass it to the function."
 
     is_vec_env = False
     if isinstance(env, VecEnv):
         is_vec_env = True
+        if env.num_envs > 1:
+            warnings.warn("You are using multiple envs, only the data from the first one will be recorded.")
 
     # Sanity check
     assert (isinstance(env.observation_space, spaces.Box) or

--- a/stable_baselines/logger.py
+++ b/stable_baselines/logger.py
@@ -53,7 +53,7 @@ class HumanOutputFormat(KVWriter, SeqWriter):
             self.file = open(filename_or_file, 'wt')
             self.own_file = True
         else:
-            assert hasattr(filename_or_file, 'read'), 'expected file or str, got %s' % filename_or_file
+            assert hasattr(filename_or_file, 'write'), 'Expected file or str, got {}'.format(filename_or_file)
             self.file = filename_or_file
             self.own_file = False
 

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -38,30 +38,24 @@ def test_gail(expert_env):
             obs = env.reset()
     del dataset, model
 
-@pytest.mark.parametrize("generate_env", [(SAC, 'MlpPolicy', 'Pendulum-v0', 1),
-                                            (DQN, 'MlpPolicy', 'CartPole-v1', 1),
-                                            (A2C, 'MlpPolicy', 'Pendulum-v0', 1),
-                                            (ACER, 'MlpPolicy', 'CartPole-v1', 1),
-                                            (PPO2, 'CnnPolicy', 'BreakoutNoFrameskip-v4', 1),
-                                            (A2C, 'MlpLstmPolicy', 'Pendulum-v0', 1),
-                                            (ACER, 'MlpLstmPolicy', 'CartPole-v1', 1),
-                                            (PPO2, 'CnnLstmPolicy', 'BreakoutNoFrameskip-v4', 1),
-                                            (A2C, 'CnnPolicy', 'BreakoutNoFrameskip-v4', 8),
-                                            (PPO2, 'CnnLstmPolicy', 'BreakoutNoFrameskip-v4', 8)])
+@pytest.mark.parametrize("generate_env", [
+                                            (SAC, 'MlpPolicy', 'Pendulum-v0', 1, 10),
+                                            (DQN, 'MlpPolicy', 'CartPole-v1', 1, 10),
+                                            (A2C, 'MlpLstmPolicy', 'Pendulum-v0', 1, 10),
+                                            (A2C, 'MlpLstmPolicy', 'CartPole-v1', 1, 10),
+                                            (A2C, 'CnnPolicy', 'BreakoutNoFrameskip-v4', 8, 1),
+                                          ])
 
 def test_generate(generate_env):
-    model, policy, env_name, n_env = generate_env
+    model, policy, env_name, n_env, n_episodes = generate_env
 
     if n_env > 1:
         env = make_atari_env(env_name, num_env=n_env, seed=0)
         model = model(policy, env, verbose=0)
     else:
-        try:
-            model = model(policy, env_name, verbose=0, nminibatches=1)
-        except TypeError:
-            model = model(policy, env_name, verbose=0)
+        model = model(policy, env_name, verbose=0)
 
-    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=15,
+    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=n_episodes,
                              image_folder='test_recorded_images')
 
 

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -38,60 +38,31 @@ def test_gail(expert_env):
             obs = env.reset()
     del dataset, model
 
-#pendulum single env support lerner single env
-def test_generate_t0():
-    model = SAC('MlpPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
+@pytest.mark.parametrize("generate_env", [(SAC, 'MlpPolicy', 'Pendulum-v0', 1),
+                                            (DQN, 'MlpPolicy', 'CartPole-v1', 1),
+                                            (A2C, 'MlpPolicy', 'Pendulum-v0', 1),
+                                            (ACER, 'MlpPolicy', 'CartPole-v1', 1),
+                                            (PPO2, 'CnnPolicy', 'BreakoutNoFrameskip-v4', 1),
+                                            (A2C, 'MlpLstmPolicy', 'Pendulum-v0', 1),
+                                            (ACER, 'MlpLstmPolicy', 'CartPole-v1', 1),
+                                            (PPO2, 'CnnLstmPolicy', 'BreakoutNoFrameskip-v4', 1),
+                                            (A2C, 'CnnPolicy', 'BreakoutNoFrameskip-v4', 8),
+                                            (PPO2, 'CnnLstmPolicy', 'BreakoutNoFrameskip-v4', 8)])
 
-#cartpole single env support lerner single env
-def test_generate_t1():
-    model = DQN('MlpPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
+def test_generate(generate_env):
+    model, policy, env_name, n_env = generate_env
 
-#pendulum multi env support lerner single env
-def test_generate_t2():
-    model = A2C('MlpPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
+    if n_env > 1:
+        env = make_atari_env(env_name, num_env=n_env, seed=0)
+        model = model(policy, env, verbose=0)
+    else:
+        try:
+            model = model(policy, env_name, verbose=0, nminibatches=1)
+        except TypeError:
+            model = model(policy, env_name, verbose=0)
 
-#cartpole multi env support lerner single env
-def test_generate_t3():
-    model = ACER('MlpPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
-
-#brackout multi env support lerner single env
-def test_generate_t4():
-    model = PPO2('CnnPolicy', 'BreakoutNoFrameskip-v4', verbose=0)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
-
-#pendulum multi env support lerner single env LSTM
-def test_generate_t5():
-    model = A2C('MlpLstmPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
-
-#cartpole multi env support lerner single env LST
-def test_generate_t6():
-    model = ACER('MlpLstmPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
-
-#brackout multi env support lerner single env LSTM
-def test_generate_t7():
-    model = PPO2('CnnLstmPolicy', 'BreakoutNoFrameskip-v4', verbose=0, nminibatches=1)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10,
-                         image_folder='test_recorded_images')
-
-#brackout multi env support lerner mulit env LSTM
-def test_generate_t8():
-    env = make_atari_env('BreakoutNoFrameskip-v4', num_env=8, seed=0)
-    model = PPO2('CnnLstmPolicy', env, verbose=0)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=100,
-                         image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=50,
+                             image_folder='test_recorded_images')
 
 
 def test_generate_callable():

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -61,7 +61,7 @@ def test_generate(generate_env):
         except TypeError:
             model = model(policy, env_name, verbose=0)
 
-    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=50,
+    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=25,
                              image_folder='test_recorded_images')
 
 

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -38,43 +38,60 @@ def test_gail(expert_env):
             obs = env.reset()
     del dataset, model
 
-
-def test_generate_pendulum_single_env_support_lerner_single_env():
+#pendulum single env support lerner single env
+def test_generate_t0():
     model = SAC('MlpPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_cartpole_single_env_support_lerner_single_env():
+#cartpole single env support lerner single env
+def test_generate_t1():
     model = DQN('MlpPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_pendulum_multi_env_support_lerner_single_env():
+#pendulum multi env support lerner single env
+def test_generate_t2():
     model = A2C('MlpPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_cartpole_multi_env_support_lerner_single_env():
+#cartpole multi env support lerner single env
+def test_generate_t3():
     model = ACER('MlpPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_brackout_multi_env_support_lerner_single_env():
+#brackout multi env support lerner single env
+def test_generate_t4():
     model = PPO2('CnnPolicy', 'BreakoutNoFrameskip-v4', verbose=0)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_pendulum_multi_env_support_lerner_single_env_LSTM():
+#pendulum multi env support lerner single env LSTM
+def test_generate_t5():
     model = A2C('MlpLstmPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_cartpole_multi_env_support_lerner_single_env_LSTM():
+#cartpole multi env support lerner single env LST
+def test_generate_t6():
     model = ACER('MlpLstmPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_brackout_multi_env_support_lerner_single_env_LSTM():
+#brackout multi env support lerner single env LSTM
+def test_generate_t7():
     model = PPO2('CnnLstmPolicy', 'BreakoutNoFrameskip-v4', verbose=0, nminibatches=1)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10,
+                         image_folder='test_recorded_images')
 
-def test_generate_brackout_multi_env_support_lerner_mulit_env_LSTM():
+#brackout multi env support lerner mulit env LSTM
+def test_generate_t8():
     env = make_atari_env('BreakoutNoFrameskip-v4', num_env=8, seed=0)
     model = PPO2('CnnLstmPolicy', env, verbose=0)
-    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=100, image_folder='test_recorded_images')
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=100,
+                         image_folder='test_recorded_images')
 
 
 def test_generate_callable():

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -61,7 +61,7 @@ def test_generate(generate_env):
         except TypeError:
             model = model(policy, env_name, verbose=0)
 
-    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=25,
+    generate_expert_traj(model, 'expert', n_timesteps=1000, n_episodes=15,
                              image_folder='test_recorded_images')
 
 

--- a/tests/test_gail.py
+++ b/tests/test_gail.py
@@ -39,14 +39,42 @@ def test_gail(expert_env):
     del dataset, model
 
 
-def test_generate_pendulum():
+def test_generate_pendulum_single_env_support_lerner_single_env():
     model = SAC('MlpPolicy', 'Pendulum-v0', verbose=0)
-    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10)
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
 
-
-def test_generate_cartpole():
+def test_generate_cartpole_single_env_support_lerner_single_env():
     model = DQN('MlpPolicy', 'CartPole-v1', verbose=0)
-    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10)
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_pendulum_multi_env_support_lerner_single_env():
+    model = A2C('MlpPolicy', 'Pendulum-v0', verbose=0)
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_cartpole_multi_env_support_lerner_single_env():
+    model = ACER('MlpPolicy', 'CartPole-v1', verbose=0)
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_brackout_multi_env_support_lerner_single_env():
+    model = PPO2('CnnPolicy', 'BreakoutNoFrameskip-v4', verbose=0)
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_pendulum_multi_env_support_lerner_single_env_LSTM():
+    model = A2C('MlpLstmPolicy', 'Pendulum-v0', verbose=0)
+    generate_expert_traj(model, 'expert_pendulum', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_cartpole_multi_env_support_lerner_single_env_LSTM():
+    model = ACER('MlpLstmPolicy', 'CartPole-v1', verbose=0)
+    generate_expert_traj(model, 'expert_cartpole', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_brackout_multi_env_support_lerner_single_env_LSTM():
+    model = PPO2('CnnLstmPolicy', 'BreakoutNoFrameskip-v4', verbose=0, nminibatches=1)
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=10, image_folder='test_recorded_images')
+
+def test_generate_brackout_multi_env_support_lerner_mulit_env_LSTM():
+    env = make_atari_env('BreakoutNoFrameskip-v4', num_env=8, seed=0)
+    model = PPO2('CnnLstmPolicy', env, verbose=0)
+    generate_expert_traj(model, 'expert_breakout', n_timesteps=1000, n_episodes=100, image_folder='test_recorded_images')
 
 
 def test_generate_callable():


### PR DESCRIPTION
This adds multi envs and LSTM support to `record_expert`. The Changes a manly to only use the first env if multiple envs a present. for LSTM support the `done` variable from the first env becomes `mask` to reset the LSTMs.
The original implementation has no test script in tests, so a am also ignoring it.

Closes #260 