### PR TITLE
Fixed path splitting in _get_latest_run_id() on Windows machines

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -10,6 +10,7 @@ Release 2.5.2a0 (WIP)
 
 - Bugfix for ``VecEnvWrapper.__getattr__`` which enables access to class attributes inherited from parent classes.
 - Removed ``get_available_gpus`` function which hadn't been used anywhere (@Pastafarianist)
+- Fixed path splitting in ``TensorboardWriter._get_latest_run_id()`` on Windows machines (@PatrickWalter214)
 
 
 Release 2.5.1 (2019-05-04)
@@ -299,4 +300,4 @@ In random order...
 
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
 @EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave @keshaviyengar @tperol
-@XMaster96 @kantneel @Pastafarianist @GerardMaggiolino
+@XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 import os
-import re
 import glob
 import warnings
 
@@ -703,7 +702,7 @@ class TensorboardWriter:
         """
         max_run_id = 0
         for path in glob.glob(self.tensorboard_log_path + "/{}_[0-9]*".format(self.tb_log_name)):
-            file_name = re.split("/|\\\\",path)[-1]
+            file_name = path.split(os.sep)[-1]
             ext = file_name.split("_")[-1]
             if self.tb_log_name == "_".join(file_name.split("_")[:-1]) and ext.isdigit() and int(ext) > max_run_id:
                 max_run_id = int(ext)

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -701,7 +701,7 @@ class TensorboardWriter:
         :return: (int) latest run number
         """
         max_run_id = 0
-        for path in glob.glob(self.tensorboard_log_path + "/{}_[0-9]*".format(self.tb_log_name)):
+        for path in glob.glob("{}/{}_[0-9]*".format(self.tensorboard_log_path, self.tb_log_name)):
             file_name = path.split(os.sep)[-1]
             ext = file_name.split("_")[-1]
             if self.tb_log_name == "_".join(file_name.split("_")[:-1]) and ext.isdigit() and int(ext) > max_run_id:

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 import os
+import re
 import glob
 import warnings
 
@@ -702,7 +703,7 @@ class TensorboardWriter:
         """
         max_run_id = 0
         for path in glob.glob(self.tensorboard_log_path + "/{}_[0-9]*".format(self.tb_log_name)):
-            file_name = path.split("/")[-1]
+            file_name = re.split("/|\\\\",path)[-1]
             ext = file_name.split("_")[-1]
             if self.tb_log_name == "_".join(file_name.split("_")[:-1]) and ext.isdigit() and int(ext) > max_run_id:
                 max_run_id = int(ext)

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -37,14 +37,15 @@ def test_tensorboard(model_name):
     assert not os.path.isdir(TENSORBOARD_DIR + logname + "_2")
 
 @pytest.mark.parametrize("model_name", MODEL_DICT.keys())
-def test_multiple_run(model_name):
-    logname = "tbTwiceWithSameLognameTest_" + model_name
+def test_multiple_runs(model_name):
+    logname = "tb_multiple_runs_" + model_name
     algo, env_id = MODEL_DICT[model_name]
     model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)
     model.learn(N_STEPS, tb_log_name=logname)
     model.learn(N_STEPS, tb_log_name=logname)
 
     assert os.path.isdir(TENSORBOARD_DIR + logname + "_1")
+    # Check that the log dir name increments correctly
     assert os.path.isdir(TENSORBOARD_DIR + logname + "_2")
 
 

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -37,7 +37,7 @@ def test_tensorboard(model_name):
     assert not os.path.isdir(TENSORBOARD_DIR + logname + "_2")
 
 @pytest.mark.parametrize("model_name", MODEL_DICT.keys())
-def test_tensorboard_twice_with_same_logname(model_name):
+def test_multiple_run(model_name):
     logname = "tbTwiceWithSameLognameTest_" + model_name
     algo, env_id = MODEL_DICT[model_name]
     model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -31,3 +31,15 @@ def test_tensorboard(model_name):
     model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)
     model.learn(N_STEPS)
     model.learn(N_STEPS, reset_num_timesteps=False)
+
+@pytest.mark.parametrize("model_name", MODEL_DICT.keys())
+def test_saving_tensorboard_twice_with_same_logname(model_name):
+    algo, env_id = MODEL_DICT[model_name]
+    model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)
+    model.learn(N_STEPS, tb_log_name=model_name)
+    model.learn(N_STEPS, tb_log_name=model_name)
+
+    assert os.path.exists(TENSORBOARD_DIR + os.sep + model_name + "_1")
+    assert os.path.exists(TENSORBOARD_DIR + os.sep + model_name + "_2")
+
+

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -27,13 +27,14 @@ N_STEPS = 1000
 
 @pytest.mark.parametrize("model_name", MODEL_DICT.keys())
 def test_tensorboard(model_name):
+    logname = model_name.upper()
     algo, env_id = MODEL_DICT[model_name]
     model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)
     model.learn(N_STEPS)
     model.learn(N_STEPS, reset_num_timesteps=False)
 
-    assert os.path.isdir(TENSORBOARD_DIR + model_name.upper() + "_1")
-    assert not os.path.isdir(TENSORBOARD_DIR + model_name.upper() + "_2")
+    assert os.path.isdir(TENSORBOARD_DIR + logname + "_1")
+    assert not os.path.isdir(TENSORBOARD_DIR + logname + "_2")
 
 @pytest.mark.parametrize("model_name", MODEL_DICT.keys())
 def test_tensorboard_twice_with_same_logname(model_name):

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -32,14 +32,18 @@ def test_tensorboard(model_name):
     model.learn(N_STEPS)
     model.learn(N_STEPS, reset_num_timesteps=False)
 
+    assert os.path.isdir(TENSORBOARD_DIR + model_name.upper() + "_1")
+    assert not os.path.isdir(TENSORBOARD_DIR + model_name.upper() + "_2")
+
 @pytest.mark.parametrize("model_name", MODEL_DICT.keys())
-def test_saving_tensorboard_twice_with_same_logname(model_name):
+def test_tensorboard_twice_with_same_logname(model_name):
+    logname = "tbTwiceWithSameLognameTest_" + model_name
     algo, env_id = MODEL_DICT[model_name]
     model = algo('MlpPolicy', env_id, verbose=1, tensorboard_log=TENSORBOARD_DIR)
-    model.learn(N_STEPS, tb_log_name=model_name)
-    model.learn(N_STEPS, tb_log_name=model_name)
+    model.learn(N_STEPS, tb_log_name=logname)
+    model.learn(N_STEPS, tb_log_name=logname)
 
-    assert os.path.isdir(TENSORBOARD_DIR + model_name + "_1")
-    assert os.path.isdir(TENSORBOARD_DIR + model_name + "_2")
+    assert os.path.isdir(TENSORBOARD_DIR + logname + "_1")
+    assert os.path.isdir(TENSORBOARD_DIR + logname + "_2")
 
 

--- a/tests/test_tensorboard.py
+++ b/tests/test_tensorboard.py
@@ -39,7 +39,7 @@ def test_saving_tensorboard_twice_with_same_logname(model_name):
     model.learn(N_STEPS, tb_log_name=model_name)
     model.learn(N_STEPS, tb_log_name=model_name)
 
-    assert os.path.exists(TENSORBOARD_DIR + os.sep + model_name + "_1")
-    assert os.path.exists(TENSORBOARD_DIR + os.sep + model_name + "_2")
+    assert os.path.isdir(TENSORBOARD_DIR + model_name + "_1")
+    assert os.path.isdir(TENSORBOARD_DIR + model_name + "_2")
 
 


### PR DESCRIPTION
When I used the library on my Windows machine it didn't create a new tb_log_name directory for each learn run and saved all tb data in the same directory. Because i use TRPO it saved all data in TRPO_1 as if reset_num_timesteps=False. But each data file started at 0 which led to strange plots.

The problem was that the glob function returned the path like this: './logs\\TRPO_1' therefore the max_run_id wouldn't increase because self.tb_log_name == "_".join(file_name.split("_")[:-1]) is never True.

I fixed this by using a regex split and additionally splitting on \\.