### PR TITLE
Save parameters as a dictionary & `load_parameters`

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -44,6 +44,11 @@ In the following example, we will train, save and load an A2C model on the Lunar
   LunarLander requires the python package `box2d`.
   You can install it using ``apt install swig`` and then ``pip install box2d box2d-kengz``
 
+.. note::
+  ``load`` function re-creates model from scratch on each call, which can be slow.
+  If you need to e.g. evaluate same model with multiple different sets of parameters, consider
+  using ``load_parameters`` instead.
+  
 .. code-block:: python
 
   import gym
@@ -309,6 +314,75 @@ However, you can also easily define a custom architecture for the policy network
   model = A2C(CustomPolicy, 'LunarLander-v2', verbose=1)
   # Train the agent
   model.learn(total_timesteps=100000)
+
+
+Accessing and modifying model parameters
+----------------------------------------
+
+You can access model's parameters via ``load_parameters`` and ``get_parameters`` functions, which
+use dictionaries that map variable names to NumPy arrays.
+
+These functions are useful when you need to e.g. evaluate large set of models with same network structure,
+visualize different layers of the network or modify parameters manually.
+
+Following example uses these functions to implement a simple `evolution strategy <http://blog.otoro.net/2017/10/29/visual-evolution-strategies/>`_ 
+for solving ``CartPole-v1`` environment.
+
+.. code-block:: python
+
+  import gym
+  import numpy as np
+
+  from stable_baselines.common.policies import MlpPolicy
+  from stable_baselines.common.vec_env import DummyVecEnv
+  from stable_baselines import A2C
+
+  def mutate(params):
+      """Mutate parameters by adding normal noise to them"""
+      return dict((name, param + np.random.normal(size=param.shape))
+                  for name, param in params.items())
+
+  def evaluate(env, model):
+      """Return mean fitness (sum of episodic rewards) for given model"""
+      episode_rewards = []
+      for _ in range(10):
+          reward_sum = 0
+          done = False
+          obs = env.reset()
+          while not done:
+              action, _states = model.predict(obs)
+              obs, reward, done, info = env.step(action)
+              reward_sum += reward
+          episode_rewards.append(reward_sum)
+      return np.mean(episode_rewards)
+
+  # Create env
+  env = gym.make('CartPole-v1')
+  env = DummyVecEnv([lambda: env])
+  # Create policy with small network.
+  model = A2C(MlpPolicy, env, policy_kwargs={'net_arch': [8, ]})
+  # Get current parameters as the starting point.
+  # `mean_params` will be a dictionary of 
+  # variable names -> numpy arrays.
+  mean_params = model.get_parameters()
+
+  for iteration in range(10):
+      # Create population of candidates and evaluate them
+      population = []
+      for population_i in range(100):
+          candidate = mutate(mean_params)
+          # Load new parameters to agent
+          model.load_parameters(candidate)
+          fitness = evaluate(env, model)
+          population.append((candidate, fitness))
+      # Take top 10% and take average over their parameters as next mean parameters
+      top_candidates = sorted(population, key=lambda x: x[1], reverse=True)[:10]
+      mean_params = dict(
+          (name, np.stack([top_candidate[0][name] for top_candidate in top_candidates]).mean(0))
+          for name in mean_params.keys()
+      )
+      mean_fitness = sum(top_candidate[1] for top_candidate in top_candidates) / 10.0
+      print("Iteration {:<3} Mean top fitness: {:.2f}".format(iteration, mean_fitness))
 
 
 Recurrent Policies

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -320,10 +320,12 @@ Accessing and modifying model parameters
 ----------------------------------------
 
 You can access model's parameters via ``load_parameters`` and ``get_parameters`` functions, which
-use dictionaries that map variable names to NumPy arrays.
+use dictionaries that map variable names to NumPy arrays. 
 
 These functions are useful when you need to e.g. evaluate large set of models with same network structure,
 visualize different layers of the network or modify parameters manually.
+
+You can access original Tensorflow Variables with function ``get_parameter_list``.
 
 Following example uses these functions to implement a simple `evolution strategy <http://blog.otoro.net/2017/10/29/visual-evolution-strategies/>`_ 
 for solving ``CartPole-v1`` environment.

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -16,7 +16,7 @@ Release 2.5.2a0 (WIP)
 - fixed a bug where number of timesteps is incorrectly updated and logged in ``A2C.learn`` and ``A2C._train_step`` (@sc420)
 - added ``load_parameters`` and ``get_parameters`` for most learning algorithms.
   With these methods, users are able to load and get parameters to/from existing model, without touching tensorflow. (@Miffyli)
-- switched to using dictionaries rather than lists when storing parameters, with tensorflow Variable names being the keys. (@Miffyli)
+- **important change** switched to using dictionaries rather than lists when storing parameters, with tensorflow Variable names being the keys. (@Miffyli)
 
 Release 2.5.1 (2019-05-04)
 --------------------------

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -306,3 +306,4 @@ In random order...
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
 @EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave @keshaviyengar @tperol
 @XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214 @yutingsz @sc420 @Aaahh @billtubbs
+@Miffyli

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -14,6 +14,9 @@ Release 2.5.2a0 (WIP)
 - The parameter ``filter_size`` of the function ``conv`` in A2C utils now supports passing a list/tuple of two integers (height and width), in order to have non-squared kernel matrix. (@yutingsz)
 - fixed a bug where initial learning rate is logged instead of its placeholder in ``A2C.setup_model`` (@sc420)
 - fixed a bug where number of timesteps is incorrectly updated and logged in ``A2C.learn`` and ``A2C._train_step`` (@sc420)
+- added ``load_parameters`` and ``get_parameters`` for most learning algorithms.
+  With these methods, users are able to load and get parameters to/from existing model, without touching tensorflow. (@Miffyli)
+- switched to using dictionaries rather than lists when storing parameters, with tensorflow Variable names being the keys. (@Miffyli)
 
 Release 2.5.1 (2019-05-04)
 --------------------------

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -292,7 +292,7 @@ class A2C(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)
 

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -292,9 +292,9 @@ class A2C(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)
 
 
 class A2CRunner(AbstractEnvRunner):

--- a/stable_baselines/acer/acer_simple.py
+++ b/stable_baselines/acer/acer_simple.py
@@ -566,7 +566,7 @@ class ACER(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)
 

--- a/stable_baselines/acer/acer_simple.py
+++ b/stable_baselines/acer/acer_simple.py
@@ -566,9 +566,9 @@ class ACER(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)
 
 
 class _Runner(AbstractEnvRunner):

--- a/stable_baselines/acktr/acktr_disc.py
+++ b/stable_baselines/acktr/acktr_disc.py
@@ -364,6 +364,6 @@ class ACKTR(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)

--- a/stable_baselines/acktr/acktr_disc.py
+++ b/stable_baselines/acktr/acktr_disc.py
@@ -364,6 +364,6 @@ class ACKTR(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -381,7 +381,7 @@ class BaseRLModel(ABC):
         elif isinstance(load_path_or_dict, list):
             warnings.warn("Warning: Loading model parameters from a list. This has been replaced " +
                           "with parameter dictionaries with variable names and parameters. " +
-                          "If you are loading from a file, consider re-saving the file.") 
+                          "If you are loading from a file, consider re-saving the file.")
             # Assume `load_path_or_dict` is list of ndarrays.
             # Create param dictionary assuming the parameters are in same order
             # as _get_parameter_list returns them.

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -413,8 +413,7 @@ class BaseRLModel(ABC):
         # Check that we updated all parameters if exact_match=True
         if exact_match and len(not_updated_variables) > 0:
             raise RuntimeError("Load dictionary did not contain all variables. " +
-                               "Missing variables: %s" %
-                               (", ".join(not_updated_variables)))
+                               "Missing variables: {}".format(", ".join(not_updated_variables)))
 
         self.sess.run(param_update_ops, feed_dict=feed_dict)
 

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -367,7 +367,7 @@ class BaseRLModel(ABC):
 
         This does not load agent's hyper-parameters.
 
-        :param load_path: (str or file-like or dict) Save parameter location
+        :param load_path_or_dict: (str or file-like or dict) Save parameter location
             or dict of parameters as variable.name -> ndarrays to be loaded.
         """
         # Make sure we have assign ops

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -156,7 +156,7 @@ class BaseRLModel(ABC):
             set_global_seeds(seed)
 
     @abstractmethod
-    def _get_parameter_list(self):
+    def get_parameter_list(self):
         """
         Get tensorflow Variables of model's parameters
 
@@ -172,7 +172,7 @@ class BaseRLModel(ABC):
 
         :return: (OrderedDict) Dictionary of variable name -> ndarray of model's parameters.
         """
-        parameters = self._get_parameter_list()
+        parameters = self.get_parameter_list()
         parameter_values = self.sess.run(parameters)
         return_dictionary = OrderedDict((param.name, value) for param, value in zip(parameters, parameter_values))
         return return_dictionary
@@ -188,7 +188,7 @@ class BaseRLModel(ABC):
         # For each loadable parameter, create appropiate
         # placeholder and an assign op, and store them to
         # self.load_param_ops as dict of variable.name -> (placeholder, assign)
-        loadable_parameters = self._get_parameter_list()
+        loadable_parameters = self.get_parameter_list()
         # Use OrderedDict to store order for backwards compatibility with
         # list-based params
         self._param_load_ops = OrderedDict()
@@ -393,7 +393,7 @@ class BaseRLModel(ABC):
                           DeprecationWarning)
             # Assume `load_path_or_dict` is list of ndarrays.
             # Create param dictionary assuming the parameters are in same order
-            # as _get_parameter_list returns them.
+            # as `get_parameter_list` returns them.
             params = dict()
             for i, param_name in enumerate(self._param_load_ops.keys()):
                 params[param_name] = load_path_or_dict[i]
@@ -650,7 +650,7 @@ class ActorCriticRLModel(BaseRLModel):
 
         return actions_proba
 
-    def _get_parameter_list(self):
+    def get_parameter_list(self):
         return self.params
 
     @abstractmethod

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -368,6 +368,10 @@ class BaseRLModel(ABC):
 
         This does not load agent's hyper-parameters.
 
+        .. warning::
+            This function does not update trainer/optimizer variables (e.g. momentum).
+            As such training after using this function may lead to less-than-optimal results.
+
         :param load_path_or_dict: (str or file-like or dict) Save parameter location
             or dict of parameters as variable.name -> ndarrays to be loaded.
         :param exact_match: (bool) If True, expects load dictionary to contain keys for

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -189,7 +189,7 @@ class BaseRLModel(ABC):
         # placeholder and an assign op, and store them to
         # self.load_param_ops as dict of variable.name -> (placeholder, assign)
         loadable_parameters = self._get_parameter_list()
-        # Use OrderedDict to store order for backwards compatability with
+        # Use OrderedDict to store order for backwards compatibility with
         # list-based params
         self._param_load_ops = OrderedDict()
         with self.graph.as_default():
@@ -379,9 +379,10 @@ class BaseRLModel(ABC):
             # Assume `load_path_or_dict` is dict of variable.name -> ndarrays we want to load
             params = load_path_or_dict
         elif isinstance(load_path_or_dict, list):
-            warnings.warn("Warning: Loading model parameters from a list. This has been replaced " +
+            warnings.warn("Loading model parameters from a list. This has been replaced " +
                           "with parameter dictionaries with variable names and parameters. " +
-                          "If you are loading from a file, consider re-saving the file.")
+                          "If you are loading from a file, consider re-saving the file.",
+                          DeprecationWarning)
             # Assume `load_path_or_dict` is list of ndarrays.
             # Create param dictionary assuming the parameters are in same order
             # as _get_parameter_list returns them.
@@ -391,7 +392,7 @@ class BaseRLModel(ABC):
         else:
             # Assume a filepath or file-like.
             # Use existing deserializer to load the parameters
-            _, params = BaseRLModel._load_from_file(load_path)
+            _, params = BaseRLModel._load_from_file(load_path_or_dict)
 
         feed_dict = {}
         param_update_ops = []

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -357,7 +357,7 @@ class BaseRLModel(ABC):
         """
         pass
 
-    def load_parameters(self, load_path):
+    def load_parameters(self, load_path_or_dict):
         """
         Load model parameters from a file or a dictionary
 
@@ -375,19 +375,19 @@ class BaseRLModel(ABC):
             self._setup_load_operations()
 
         params = None
-        if isinstance(load_path, dict):
-            # Assume `load_path` is dict of variable.name -> ndarrays we want to load
-            params = load_path
-        elif isinstance(load_path, list):
+        if isinstance(load_path_or_dict, dict):
+            # Assume `load_path_or_dict` is dict of variable.name -> ndarrays we want to load
+            params = load_path_or_dict
+        elif isinstance(load_path_or_dict, list):
             warnings.warn("Warning: Loading model parameters from a list. This has been replaced " +
                           "with parameter dictionaries with variable names and parameters. " +
                           "If you are loading from a file, consider re-saving the file.") 
-            # Assume `load_path` is list of ndarrays.
+            # Assume `load_path_or_dict` is list of ndarrays.
             # Create param dictionary assuming the parameters are in same order
             # as _get_parameter_list returns them.
             params = dict()
             for i, param_name in enumerate(self._param_load_ops.keys()):
-                params[param_name] = load_path[i]
+                params[param_name] = load_path_or_dict[i]
         else:
             # Assume a filepath or file-like.
             # Use existing deserializer to load the parameters

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -170,11 +170,11 @@ class BaseRLModel(ABC):
         """
         Get current model parameters as dictionary of variable name -> ndarray.
 
-        :return: (dict) Dictionary of variable name -> ndarray of model's parameters.
+        :return: (OrderedDict) Dictionary of variable name -> ndarray of model's parameters.
         """
         parameters = self._get_parameter_list()
         parameter_values = self.sess.run(parameters)
-        return_dictionary = dict((param.name, value) for param, value in zip(parameters, parameter_values))
+        return_dictionary = OrderedDict((param.name, value) for param, value in zip(parameters, parameter_values))
         return return_dictionary
 
     def _setup_load_operations(self):

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -988,6 +988,12 @@ class DDPG(OffPolicyRLModel):
         warnings.warn("Warning: action probability is meaningless for DDPG. Returning None")
         return None
 
+    def get_parameters(self):
+        return (self.params +
+                self.target_params +
+                self.obs_rms_params +
+                self.ret_rms_params)
+
     def save(self, save_path):
         data = {
             "observation_space": self.observation_space,
@@ -1020,15 +1026,8 @@ class DDPG(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
-        target_params = self.sess.run(self.target_params)
-        norm_obs_params = self.sess.run(self.obs_rms_params)
-        norm_ret_params = self.sess.run(self.ret_rms_params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        params_to_save = params \
-            + target_params \
-            + norm_obs_params \
-            + norm_ret_params
         self._save_to_file(save_path,
                            data=data,
                            params=params_to_save)
@@ -1049,13 +1048,6 @@ class DDPG(OffPolicyRLModel):
         model.set_env(env)
         model.setup_model()
 
-        restores = []
-        params_to_load = model.params \
-            + model.target_params \
-            + model.obs_rms_params \
-            + model.ret_rms_params
-        for param, loaded_p in zip(params_to_load, params):
-            restores.append(param.assign(loaded_p))
-        model.sess.run(restores)
+        model.load_parameters(params)
 
         return model

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -988,7 +988,7 @@ class DDPG(OffPolicyRLModel):
         warnings.warn("Warning: action probability is meaningless for DDPG. Returning None")
         return None
 
-    def _get_parameter_list(self):
+    def get_parameter_list(self):
         return (self.params +
                 self.target_params +
                 self.obs_rms_params +

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -1032,7 +1032,6 @@ class DDPG(OffPolicyRLModel):
                            data=data,
                            params=params_to_save)
 
-
     @classmethod
     def load(cls, load_path, env=None, **kwargs):
         data, params = cls._load_from_file(load_path)

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -988,7 +988,7 @@ class DDPG(OffPolicyRLModel):
         warnings.warn("Warning: action probability is meaningless for DDPG. Returning None")
         return None
 
-    def get_parameters(self):
+    def _get_parameter_list(self):
         return (self.params +
                 self.target_params +
                 self.obs_rms_params +
@@ -1026,7 +1026,7 @@ class DDPG(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path,
                            data=data,

--- a/stable_baselines/deepq/dqn.py
+++ b/stable_baselines/deepq/dqn.py
@@ -310,7 +310,7 @@ class DQN(OffPolicyRLModel):
 
         return actions_proba
 
-    def get_parameters(self):
+    def _get_parameter_list(self):
         return self.params
 
     def save(self, save_path):
@@ -341,7 +341,7 @@ class DQN(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)
 

--- a/stable_baselines/deepq/dqn.py
+++ b/stable_baselines/deepq/dqn.py
@@ -310,7 +310,7 @@ class DQN(OffPolicyRLModel):
 
         return actions_proba
 
-    def _get_parameter_list(self):
+    def get_parameter_list(self):
         return self.params
 
     def save(self, save_path):

--- a/stable_baselines/deepq/dqn.py
+++ b/stable_baselines/deepq/dqn.py
@@ -310,6 +310,9 @@ class DQN(OffPolicyRLModel):
 
         return actions_proba
 
+    def get_parameters(self):
+        return self.params
+
     def save(self, save_path):
         # params
         data = {
@@ -338,9 +341,9 @@ class DQN(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)
 
     @classmethod
     def load(cls, load_path, env=None, **kwargs):
@@ -357,9 +360,6 @@ class DQN(OffPolicyRLModel):
         model.set_env(env)
         model.setup_model()
 
-        restores = []
-        for param, loaded_p in zip(model.params, params):
-            restores.append(param.assign(loaded_p))
-        model.sess.run(restores)
+        model.load_parameters(params)
 
         return model

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -354,6 +354,6 @@ class PPO1(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)

--- a/stable_baselines/ppo1/pposgd_simple.py
+++ b/stable_baselines/ppo1/pposgd_simple.py
@@ -354,6 +354,6 @@ class PPO1(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)

--- a/stable_baselines/ppo2/ppo2.py
+++ b/stable_baselines/ppo2/ppo2.py
@@ -380,7 +380,7 @@ class PPO2(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)
 

--- a/stable_baselines/ppo2/ppo2.py
+++ b/stable_baselines/ppo2/ppo2.py
@@ -380,9 +380,9 @@ class PPO2(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)
 
 
 class Runner(AbstractEnvRunner):

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -495,6 +495,10 @@ class SAC(OffPolicyRLModel):
 
         return actions, None
 
+    def get_parameters(self):
+        return (self.params +
+                self.target_params)
+
     def save(self, save_path):
         data = {
             "learning_rate": self.learning_rate,
@@ -519,10 +523,9 @@ class SAC(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
-        target_params = self.sess.run(self.target_params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params + target_params)
+        self._save_to_file(save_path, data=data, params=params_to_save)
 
     @classmethod
     def load(cls, load_path, env=None, **kwargs):
@@ -539,9 +542,6 @@ class SAC(OffPolicyRLModel):
         model.set_env(env)
         model.setup_model()
 
-        restores = []
-        for param, loaded_p in zip(model.params + model.target_params, params):
-            restores.append(param.assign(loaded_p))
-        model.sess.run(restores)
+        model.load_parameters(params)
 
         return model

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -495,7 +495,7 @@ class SAC(OffPolicyRLModel):
 
         return actions, None
 
-    def _get_parameter_list(self):
+    def get_parameter_list(self):
         return (self.params +
                 self.target_params)
 

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -495,7 +495,7 @@ class SAC(OffPolicyRLModel):
 
         return actions, None
 
-    def get_parameters(self):
+    def _get_parameter_list(self):
         return (self.params +
                 self.target_params)
 
@@ -523,7 +523,7 @@ class SAC(OffPolicyRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)
 

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -511,6 +511,6 @@ class TRPO(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params = self.sess.run(self.params)
+        params_to_save = self.sess.run(self.get_parameters())
 
-        self._save_to_file(save_path, data=data, params=params)
+        self._save_to_file(save_path, data=data, params=params_to_save)

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -511,6 +511,6 @@ class TRPO(ActorCriticRLModel):
             "policy_kwargs": self.policy_kwargs
         }
 
-        params_to_save = self.sess.run(self.get_parameters())
+        params_to_save = self.get_parameters()
 
         self._save_to_file(save_path, data=data, params=params_to_save)

--- a/tests/test_load_parameters.py
+++ b/tests/test_load_parameters.py
@@ -106,8 +106,8 @@ def test_load_parameters(request, model_class):
         model.load_parameters(b_io)
         b_io.close()
         new_actions_probas = model.action_probability(observations, actions=actions)
-        assert np.all(np.isclose(original_actions_probas, new_actions_probas)), "Action probabilities changed " \
-                                                                                "after load_parameters from a file-like."
+        assert np.all(np.isclose(original_actions_probas, new_actions_probas)), "Action probabilities changed after" \
+                                                                                "load_parameters from a file-like."
     finally:
         if os.path.exists(model_fname):
             os.remove(model_fname)

--- a/tests/test_load_parameters.py
+++ b/tests/test_load_parameters.py
@@ -1,10 +1,7 @@
-import os
-
 import pytest
 import numpy as np
 
-from stable_baselines import A2C, ACER, ACKTR, DQN, PPO1, PPO2, TRPO, SAC
-from stable_baselines.common import set_global_seeds
+from stable_baselines import A2C, ACER, ACKTR, DQN, PPO1, PPO2, TRPO
 from stable_baselines.common.identity_env import IdentityEnv
 from stable_baselines.common.vec_env import DummyVecEnv
 
@@ -43,7 +40,7 @@ def test_load_parameters(request, model_class):
     # Get dictionary of current parameters
     params = model.get_parameters()
     # Modify all parameters to be random values
-    random_params = dict((param_name, np.random.random(size=param.shape)) for param_name,param in params.items())
+    random_params = dict((param_name, np.random.random(size=param.shape)) for param_name, param in params.items())
     # Update model parameters with the new zeroed values
     model.load_parameters(random_params)
     # Get new action probas
@@ -70,7 +67,8 @@ def test_load_parameters(request, model_class):
 
     # Compare results against the previous load
     new_actions_probas_list = model.action_probability(observations, actions=actions)
-    assert not np.any(np.isclose(new_actions_probas, new_actions_probas_list)), "Action probabilities did not change " \
-                                                                                "after changing model parameters (list)."
+    assert not np.any(np.isclose(new_actions_probas, new_actions_probas_list)), "Action probabilities did not " \
+                                                                                "change after changing model " \
+                                                                                "parameters (list)."
 
     del model, env

--- a/tests/test_load_parameters.py
+++ b/tests/test_load_parameters.py
@@ -1,0 +1,76 @@
+import os
+
+import pytest
+import numpy as np
+
+from stable_baselines import A2C, ACER, ACKTR, DQN, PPO1, PPO2, TRPO, SAC
+from stable_baselines.common import set_global_seeds
+from stable_baselines.common.identity_env import IdentityEnv
+from stable_baselines.common.vec_env import DummyVecEnv
+
+MODEL_LIST = [
+    A2C,
+    ACER,
+    ACKTR,
+    DQN,
+    PPO1,
+    PPO2,
+    TRPO,
+]
+
+@pytest.mark.parametrize("model_class", MODEL_LIST)
+def test_load_parameters(request, model_class):
+    """
+    Test if ``load_parameters`` loads given parameters correctly (the model actually changes)
+    and that the backwards compatability with a list of params works
+
+    :param model_class: (BaseRLModel) A RL model
+    """
+    env = DummyVecEnv([lambda: IdentityEnv(10)])
+
+    # create model
+    model = model_class(policy="MlpPolicy", env=env)
+
+    # test action probability for given (obs, action) pair
+    env = model.get_env()
+    obs = env.reset()
+    observations = np.array([obs for _ in range(10)])
+    observations = np.squeeze(observations)
+
+    actions = np.array([env.action_space.sample() for _ in range(10)])
+    original_actions_probas = model.action_probability(observations, actions=actions)
+
+    # Get dictionary of current parameters
+    params = model.get_parameters()
+    # Modify all parameters to be random values
+    random_params = dict((param_name, np.random.random(size=param.shape)) for param_name,param in params.items())
+    # Update model parameters with the new zeroed values
+    model.load_parameters(random_params)
+    # Get new action probas
+    new_actions_probas = model.action_probability(observations, actions=actions)
+
+    # Check that at least some action probabilities are different now
+    assert not np.any(np.isclose(original_actions_probas, new_actions_probas)), "Action probabilities did not change " \
+                                                                                "after changing model parameters."
+    # Also check that new parameters are there (they should be random_params)
+    new_params = model.get_parameters()
+    comparisons = [np.all(np.isclose(new_params[key], random_params[key])) for key in random_params.keys()]
+    assert all(comparisons), "Parameters of model are not the same as provided ones."
+
+    # Now test the backwards compatibility with params being a list instead of a dict.
+    # Since `get_parameters` returns a dictionary, we can not trust the ordering (prior Python 3.7),
+    # we get the exact ordering from private method `_get_parameter_list()`.
+    # Same function is used in case .pkl files store a list, so this test will also cover that
+    # scenario.
+    tf_param_list = model._get_parameter_list()
+    # Make random parameters negative to make sure the results should be different from
+    # previous random values
+    random_param_list = [-np.random.random(size=tf_param.shape) for tf_param in tf_param_list]
+    model.load_parameters(random_param_list)
+
+    # Compare results against the previous load
+    new_actions_probas_list = model.action_probability(observations, actions=actions)
+    assert not np.any(np.isclose(new_actions_probas, new_actions_probas_list)), "Action probabilities did not change " \
+                                                                                "after changing model parameters (list)."
+
+    del model, env

--- a/tests/test_load_parameters.py
+++ b/tests/test_load_parameters.py
@@ -59,11 +59,8 @@ def test_load_parameters(request, model_class):
 
 
     # Now test the backwards compatibility with params being a list instead of a dict.
-    # Since `get_parameters` returns a dictionary, we can not trust the ordering (prior Python 3.7),
-    # we get the exact ordering from private method `_get_parameter_list()`.
-    # Same function is used in case .pkl files store a list, so this test will also cover that
-    # scenario.
-    tf_param_list = model._get_parameter_list()
+    # Get the ordering of parameters.
+    tf_param_list = model.get_parameter_list()
     # Make random parameters negative to make sure the results should be different from
     # previous random values
     random_param_list = [-np.random.random(size=tf_param.shape) for tf_param in tf_param_list]

--- a/tests/test_load_parameters.py
+++ b/tests/test_load_parameters.py
@@ -16,7 +16,7 @@ MODEL_LIST = [
 ]
 
 @pytest.mark.parametrize("model_class", MODEL_LIST)
-def test_load_parameters(request, model_class):
+def test_load_parameters(model_class):
     """
     Test if ``load_parameters`` loads given parameters correctly (the model actually changes)
     and that the backwards compatability with a list of params works


### PR DESCRIPTION
As discussed in #312, this PR adds two things:

- Model parameters are stored in a dictionary rather than a list. Dictionary keys are tensorflow Variable names.
- Adds `load_parameters` and `get_parameters` functions for loading/getting parameters from an existing model (including tests for these functions).

A modification to `BaseRLModel`: 

- Adds abstract method `_get_parameter_list`, which should return list of tensorflow Variables needed for saving/loading the model. Replaces the lists previously defined in `save`.

closes #312
closes #113 