### PR TITLE
'prng' was removed in latest gym version

### DIFF
--- a/stable_baselines/common/misc_util.py
+++ b/stable_baselines/common/misc_util.py
@@ -89,7 +89,9 @@ def set_global_seeds(seed):
     tf.set_random_seed(seed)
     np.random.seed(seed)
     random.seed(seed)
-    gym.spaces.prng.seed(seed)
+    # prng was removed in latest gym version
+    if hasattr(gym.spaces, 'prng'):
+        gym.spaces.prng.seed(seed)
 
 
 def pretty_eta(seconds_left):


### PR DESCRIPTION
Salut @hill-a ,

Congrats for the work done on Stable Baselines & on this branch 'deterministic-fix'

While trying this branch, I've noticed it wouldn't work like the 'master' when using "set_global_seeds" and crash my code

Thus, regardless of your intention to merge this branch into the main one at some point ( which I hope? :) if possible ? ), you will find here my small correction to this branch to be able to work with latest GYM environment not having "prng" attributes anymore

Merci & congrats again for this project
Best
Lucas