### PR TITLE
Add 'terminal_observation' info key to vecenvs

### DIFF
--- a/docs/guide/vec_envs.rst
+++ b/docs/guide/vec_envs.rst
@@ -26,6 +26,8 @@ SubprocVecEnv ✔️       ✔️           ✔️        ✔️         ✔️
 .. note::
 
 	When using vectorized environments, the environments are automatically reset at the end of each episode.
+	Thus, the observation returned for the i-th environment when ``done[i]`` is true will in fact be the first observation of the next episode, not the last observation of the episode that has just terminated.
+	You can access the "real" final observation of the terminated episode—that is, the one that accompanied the ``done`` event provided by the underlying environment—using the ``terminal_observation`` keys in the info dicts returned by the vecenv.
 
 .. warning::
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ New Features:
   policy in addition to the existing support for categorical stochastic policies.
 - Add flag to `action_probability` to return log-probabilities.
 - Added support for python lists and numpy arrays in ``logger.writekvs``. (@dwiel)
+- The info dicts returned by VecEnvs now include a ``terminal_observation`` key providing access to the last observation in a trajectory.
 
 Bug Fixes:
 ^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,7 +19,7 @@ New Features:
   policy in addition to the existing support for categorical stochastic policies.
 - Add flag to `action_probability` to return log-probabilities.
 - Added support for python lists and numpy arrays in ``logger.writekvs``. (@dwiel)
-- The info dicts returned by VecEnvs now include a ``terminal_observation`` key providing access to the last observation in a trajectory.
+- The info dicts returned by VecEnvs now include a ``terminal_observation`` key providing access to the last observation in a trajectory. (@qxcv)
 
 Bug Fixes:
 ^^^^^^^^^^
@@ -409,4 +409,4 @@ In random order...
 Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
 @EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave @keshaviyengar @tperol
 @XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214 @yutingsz @sc420 @Aaahh @billtubbs
-@Miffyli @dwiel @miguelrass
+@Miffyli @dwiel @miguelrass @qxcv

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -39,6 +39,7 @@ class DummyVecEnv(VecEnv):
             obs, self.buf_rews[env_idx], self.buf_dones[env_idx], self.buf_infos[env_idx] =\
                 self.envs[env_idx].step(self.actions[env_idx])
             if self.buf_dones[env_idx]:
+                self.buf_infos[env_idx]['terminal_observation'] = obs
                 obs = self.envs[env_idx].reset()
             self._save_obs(env_idx, obs)
         return (self._obs_from_buf(), np.copy(self.buf_rews), np.copy(self.buf_dones),

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -39,6 +39,7 @@ class DummyVecEnv(VecEnv):
             obs, self.buf_rews[env_idx], self.buf_dones[env_idx], self.buf_infos[env_idx] =\
                 self.envs[env_idx].step(self.actions[env_idx])
             if self.buf_dones[env_idx]:
+                # save final observation where user can get it, then reset
                 self.buf_infos[env_idx]['terminal_observation'] = obs
                 obs = self.envs[env_idx].reset()
             self._save_obs(env_idx, obs)

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -17,6 +17,7 @@ def _worker(remote, parent_remote, env_fn_wrapper):
             if cmd == 'step':
                 observation, reward, done, info = env.step(data)
                 if done:
+                    info['terminal_observation'] = observation
                     observation = env.reset()
                 remote.send((observation, reward, done, info))
             elif cmd == 'reset':

--- a/stable_baselines/common/vec_env/subproc_vec_env.py
+++ b/stable_baselines/common/vec_env/subproc_vec_env.py
@@ -17,6 +17,7 @@ def _worker(remote, parent_remote, env_fn_wrapper):
             if cmd == 'step':
                 observation, reward, done, info = env.step(data)
                 if done:
+                    # save final observation where user can get it, then reset
                     info['terminal_observation'] = observation
                     observation = env.reset()
                 remote.send((observation, reward, done, info))

--- a/stable_baselines/common/vec_env/vec_frame_stack.py
+++ b/stable_baselines/common/vec_env/vec_frame_stack.py
@@ -11,7 +11,7 @@ class VecFrameStack(VecEnvWrapper):
     :param venv: (VecEnv) the vectorized environment to wrap
     :param n_stack: (int) Number of frames to stack
     """
-    
+
     def __init__(self, venv, n_stack):
         self.venv = venv
         self.n_stack = n_stack
@@ -24,9 +24,14 @@ class VecFrameStack(VecEnvWrapper):
 
     def step_wait(self):
         observations, rewards, dones, infos = self.venv.step_wait()
-        self.stackedobs = np.roll(self.stackedobs, shift=-observations.shape[-1], axis=-1)
+        last_ax_size = observations.shape[-1]
+        self.stackedobs = np.roll(self.stackedobs, shift=-last_ax_size, axis=-1)
         for i, done in enumerate(dones):
             if done:
+                old_terminal = infos[i]['terminal_observation']
+                new_terminal = np.concatenate(
+                    (self.stackedobs[i, ..., :-last_ax_size], old_terminal), axis=-1)
+                infos[i]['terminal_observation'] = new_terminal
                 self.stackedobs[i] = 0
         self.stackedobs[..., -observations.shape[-1]:] = observations
         return self.stackedobs, rewards, dones, infos

--- a/stable_baselines/common/vec_env/vec_frame_stack.py
+++ b/stable_baselines/common/vec_env/vec_frame_stack.py
@@ -37,7 +37,7 @@ class VecFrameStack(VecEnvWrapper):
                     infos[i]['terminal_observation'] = new_terminal
                 else:
                     warnings.warn(
-                        "VecFrameStack wrapping a vecenv without terminal_observation info")
+                        "VecFrameStack wrapping a VecEnv without terminal_observation info")
                 self.stackedobs[i] = 0
         self.stackedobs[..., -observations.shape[-1]:] = observations
         return self.stackedobs, rewards, dones, infos

--- a/stable_baselines/common/vec_env/vec_frame_stack.py
+++ b/stable_baselines/common/vec_env/vec_frame_stack.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from gym import spaces
 
@@ -28,10 +30,14 @@ class VecFrameStack(VecEnvWrapper):
         self.stackedobs = np.roll(self.stackedobs, shift=-last_ax_size, axis=-1)
         for i, done in enumerate(dones):
             if done:
-                old_terminal = infos[i]['terminal_observation']
-                new_terminal = np.concatenate(
-                    (self.stackedobs[i, ..., :-last_ax_size], old_terminal), axis=-1)
-                infos[i]['terminal_observation'] = new_terminal
+                if 'terminal_observation' in infos[i]:
+                    old_terminal = infos[i]['terminal_observation']
+                    new_terminal = np.concatenate(
+                        (self.stackedobs[i, ..., :-last_ax_size], old_terminal), axis=-1)
+                    infos[i]['terminal_observation'] = new_terminal
+                else:
+                    warnings.warn(
+                        "VecFrameStack wrapping a vecenv without terminal_observation info")
                 self.stackedobs[i] = 0
         self.stackedobs[..., -observations.shape[-1]:] = observations
         return self.stackedobs, rewards, dones, infos


### PR DESCRIPTION
This adds a `terminal_observation` key to the `info` dicts returned by vecenvs when they encounter the end of an episode. This fixes #400: see that issue for details.