### PR TITLE
Fix action scaling for warmup exploration (SAC/DDPG/TD3)

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -34,7 +34,7 @@ Bug Fixes:
 - Fix a bug in DDPG where `predict` method with `deterministic=False` would fail
 - Fix a bug in TRPO: mean_losses was not initialized causing the logger to crash when there was no gradients (@MarvineGothic)
 - Fix a bug in `cmd_util` from API change in recent Gym versions
-- Fix a bug in DDPG, TD3 and SAC where warmup actions would end up scaled in the replay buffer
+- Fix a bug in DDPG, TD3 and SAC where warmup and random exploration actions would end up scaled in the replay buffer
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -34,7 +34,7 @@ Bug Fixes:
 - Fix a bug in DDPG where `predict` method with `deterministic=False` would fail
 - Fix a bug in TRPO: mean_losses was not initialized causing the logger to crash when there was no gradients (@MarvineGothic)
 - Fix a bug in `cmd_util` from API change in recent Gym versions
-- Fix a bug in DDPG, TD3 and SAC where warmup and random exploration actions would end up scaled in the replay buffer
+- Fix a bug in DDPG, TD3 and SAC where warmup and random exploration actions would end up scaled in the replay buffer (@Antymon)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -27,6 +27,7 @@ New Features:
 - Add parameter `exploration_initial_eps` to DQN. (@jdossgollin)
 - Add type checking and PEP 561 compliance.
   Note: most functions are still not annotated, this will be a gradual process.
+- DDPG, TD3 and SAC accept non-symmetric action spaces. (@Antymon)
 
 Bug Fixes:
 ^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -34,6 +34,7 @@ Bug Fixes:
 - Fix a bug in DDPG where `predict` method with `deterministic=False` would fail
 - Fix a bug in TRPO: mean_losses was not initialized causing the logger to crash when there was no gradients (@MarvineGothic)
 - Fix a bug in `cmd_util` from API change in recent Gym versions
+- Fix a bug in DDPG, TD3 and SAC where warmup actions would end up scaled in the replay buffer
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines/common/math_util.py
+++ b/stable_baselines/common/math_util.py
@@ -101,3 +101,29 @@ def discount_with_boundaries(rewards, episode_starts, gamma):
     for step in range(n_samples - 2, -1, -1):
         discounted_rewards[step] = rewards[step] + gamma * discounted_rewards[step + 1] * (1 - episode_starts[step + 1])
     return discounted_rewards
+
+
+def scale_action(action_space, action):
+    """
+    Rescale the action from [low, high] to [-1, 1]
+    (no need for symmetric action space)
+
+    :param action_space: (gym.spaces.box.Box)
+    :param action: (np.ndarray)
+    :return: (np.ndarray)
+    """
+    low, high = action_space.low, action_space.high
+    return 2.0 * ((action - low) / (high - low)) - 1.0
+
+
+def unscale_action(action_space, scaled_action):
+    """
+    Rescale the action from [-1, 1] to [low, high]
+    (no need for symmetric action space)
+
+    :param action_space: (gym.spaces.box.Box)
+    :param action: (np.ndarray)
+    :return: (np.ndarray)
+    """
+    low, high = action_space.low, action_space.high
+    return low + (0.5 * (scaled_action + 1.0) * (high - low))

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -870,7 +870,7 @@ class DDPG(OffPolicyRLModel):
                             if rank == 0 and self.render:
                                 self.env.render()
 
-                            # Randomly sample actions from a uniform distributiontrain_freq
+                            # Randomly sample actions from a uniform distribution
                             # with a probabilty self.random_exploration (used in HER + DDPG)
                             if np.random.rand() < self.random_exploration:
                                 unscaled_action = self.action_space.sample()

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -15,6 +15,7 @@ from stable_baselines import logger
 from stable_baselines.common import tf_util, OffPolicyRLModel, SetVerbosity, TensorboardWriter
 from stable_baselines.common.vec_env import VecEnv
 from stable_baselines.common.mpi_adam import MpiAdam
+from stable_baselines.common.math_util import scale_action, unscale_action
 from stable_baselines.ddpg.policies import DDPGPolicy
 from stable_baselines.common.mpi_running_mean_std import RunningMeanStd
 from stable_baselines.a2c.utils import total_episode_reward_logger
@@ -872,9 +873,10 @@ class DDPG(OffPolicyRLModel):
                             # Randomly sample actions from a uniform distribution
                             # with a probabilty self.random_exploration (used in HER + DDPG)
                             if np.random.rand() < self.random_exploration:
-                                rescaled_action = action = self.action_space.sample()
+                                rescaled_action = self.action_space.sample()
+                                action = unscale_action(self.action_space, rescaled_action)
                             else:
-                                rescaled_action = action * np.abs(self.action_space.low)
+                                rescaled_action = scale_action(self.action_space, action)
 
                             new_obs, reward, done, info = self.env.step(rescaled_action)
 

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -819,8 +819,7 @@ class DDPG(OffPolicyRLModel):
             self.tb_seen_steps = []
 
             rank = MPI.COMM_WORLD.Get_rank()
-            # we assume symmetric actions.
-            assert np.all(np.abs(self.env.action_space.low) == self.env.action_space.high)
+
             if self.verbose >= 2:
                 logger.log('Using agent with the following configuration:')
                 logger.log(str(self.__dict__.items()))

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -313,7 +313,7 @@ class DDPG(OffPolicyRLModel):
     def _get_pretrain_placeholders(self):
         policy = self.policy_tf
         # Rescale
-        deterministic_action = self.actor_tf * np.abs(self.action_space.low)
+        deterministic_action = scale_action(self.action_space, self.actor_tf)
         return policy.obs_ph, self.actions, deterministic_action
 
     def setup_model(self):
@@ -957,8 +957,8 @@ class DDPG(OffPolicyRLModel):
                                     return self
 
                                 eval_action, eval_q = self._policy(eval_obs, apply_noise=False, compute_q=True)
-                                eval_obs, eval_r, eval_done, _ = self.eval_env.step(eval_action *
-                                                                                    np.abs(self.action_space.low))
+                                rescaled_action = scale_action(self.action_space, eval_action)
+                                eval_obs, eval_r, eval_done, _ = self.eval_env.step(rescaled_action)
                                 if self.render_eval:
                                     self.eval_env.render()
                                 eval_episode_reward += eval_r
@@ -1043,7 +1043,7 @@ class DDPG(OffPolicyRLModel):
         observation = observation.reshape((-1,) + self.observation_space.shape)
         actions, _, = self._policy(observation, apply_noise=not deterministic, compute_q=False)
         actions = actions.reshape((-1,) + self.action_space.shape)  # reshape to the correct action shape
-        actions = actions * np.abs(self.action_space.low)  # scale the output for the prediction
+        actions = scale_action(self.action_space, actions)  # scale the output for the prediction
 
         if not vectorized_env:
             actions = actions[0]

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -872,9 +872,12 @@ class DDPG(OffPolicyRLModel):
                             # Randomly sample actions from a uniform distribution
                             # with a probabilty self.random_exploration (used in HER + DDPG)
                             if np.random.rand() < self.random_exploration:
+                                # actions sampled from action space are from range specific to the environment
+                                # but algorithm operates on tanh-squashed actions therefore simple scaling is used
                                 unscaled_action = self.action_space.sample()
                                 action = scale_action(self.action_space, unscaled_action)
                             else:
+                                # inferred actions need to be transformed to environment action_space before stepping
                                 unscaled_action = unscale_action(self.action_space, action)
 
                             new_obs, reward, done, info = self.env.step(unscaled_action)

--- a/stable_baselines/ddpg/ddpg.py
+++ b/stable_baselines/ddpg/ddpg.py
@@ -873,12 +873,12 @@ class DDPG(OffPolicyRLModel):
                             # Randomly sample actions from a uniform distributiontrain_freq
                             # with a probabilty self.random_exploration (used in HER + DDPG)
                             if np.random.rand() < self.random_exploration:
-                                rescaled_action = self.action_space.sample()
-                                action = scale_action(self.action_space, rescaled_action)
+                                unscaled_action = self.action_space.sample()
+                                action = scale_action(self.action_space, unscaled_action)
                             else:
-                                rescaled_action = unscale_action(self.action_space, action)
+                                unscaled_action = unscale_action(self.action_space, action)
 
-                            new_obs, reward, done, info = self.env.step(rescaled_action)
+                            new_obs, reward, done, info = self.env.step(unscaled_action)
 
                             if writer is not None:
                                 ep_rew = np.array([reward]).reshape((1, -1))
@@ -957,8 +957,8 @@ class DDPG(OffPolicyRLModel):
                                     return self
 
                                 eval_action, eval_q = self._policy(eval_obs, apply_noise=False, compute_q=True)
-                                rescaled_action = unscale_action(self.action_space, eval_action)
-                                eval_obs, eval_r, eval_done, _ = self.eval_env.step(rescaled_action)
+                                unscaled_action = unscale_action(self.action_space, eval_action)
+                                eval_obs, eval_r, eval_done, _ = self.eval_env.step(unscaled_action)
                                 if self.render_eval:
                                     self.eval_env.render()
                                 eval_episode_reward += eval_r

--- a/stable_baselines/ddpg/policies.py
+++ b/stable_baselines/ddpg/policies.py
@@ -23,7 +23,6 @@ class DDPGPolicy(BasePolicy):
         super(DDPGPolicy, self).__init__(sess, ob_space, ac_space, n_env, n_steps, n_batch, reuse=reuse, scale=scale,
                                          add_action_ph=True)
         assert isinstance(ac_space, Box), "Error: the action space must be of type gym.spaces.Box"
-        assert (np.abs(ac_space.low) == ac_space.high).all(), "Error: the action space low and high must be symmetric"
         self.qvalue_fn = None
         self.policy = None
 

--- a/stable_baselines/sac/policies.py
+++ b/stable_baselines/sac/policies.py
@@ -99,7 +99,6 @@ class SACPolicy(BasePolicy):
     def __init__(self, sess, ob_space, ac_space, n_env=1, n_steps=1, n_batch=None, reuse=False, scale=False):
         super(SACPolicy, self).__init__(sess, ob_space, ac_space, n_env, n_steps, n_batch, reuse=reuse, scale=scale)
         assert isinstance(ac_space, Box), "Error: the action space must be of type gym.spaces.Box"
-        assert (np.abs(ac_space.low) == ac_space.high).all(), "Error: the action space low and high must be symmetric"
 
         self.qf1 = None
         self.qf2 = None

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -408,19 +408,19 @@ class SAC(OffPolicyRLModel):
                 # if random_exploration is set to 0 (normal setting)
                 if (self.num_timesteps < self.learning_starts
                     or np.random.rand() < self.random_exploration):
-                    rescaled_action = self.env.action_space.sample()
-                    action = scale_action(self.action_space, rescaled_action)
+                    unscaled_action = self.env.action_space.sample()
+                    action = scale_action(self.action_space, unscaled_action)
                 else:
                     action = self.policy_tf.step(obs[None], deterministic=False).flatten()
                     # Add noise to the action (improve exploration,
                     # not needed in general)
                     if self.action_noise is not None:
                         action = np.clip(action + self.action_noise(), -1, 1)
-                    rescaled_action = unscale_action(self.action_space, action)
+                    unscaled_action = unscale_action(self.action_space, action)
 
                 assert action.shape == self.env.action_space.shape
 
-                new_obs, reward, done, info = self.env.step(rescaled_action)
+                new_obs, reward, done, info = self.env.step(unscaled_action)
 
                 # Store transition in the replay buffer.
                 self.replay_buffer.add(obs, action, reward, new_obs, float(done))

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -406,8 +406,9 @@ class SAC(OffPolicyRLModel):
                 # from a uniform distribution for better exploration.
                 # Afterwards, use the learned policy
                 # if random_exploration is set to 0 (normal setting)
-                if (self.num_timesteps < self.learning_starts
-                    or np.random.rand() < self.random_exploration):
+                if self.num_timesteps < self.learning_starts or np.random.rand() < self.random_exploration:
+                    # actions sampled from action space are from range specific to the environment
+                    # but algorithm operates on tanh-squashed actions therefore simple scaling is used
                     unscaled_action = self.env.action_space.sample()
                     action = scale_action(self.action_space, unscaled_action)
                 else:
@@ -416,6 +417,7 @@ class SAC(OffPolicyRLModel):
                     # not needed in general)
                     if self.action_noise is not None:
                         action = np.clip(action + self.action_noise(), -1, 1)
+                    # inferred actions need to be transformed to environment action_space before stepping
                     unscaled_action = unscale_action(self.action_space, action)
 
                 assert action.shape == self.env.action_space.shape

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -140,7 +140,7 @@ class SAC(OffPolicyRLModel):
     def _get_pretrain_placeholders(self):
         policy = self.policy_tf
         # Rescale
-        deterministic_action = self.deterministic_action * np.abs(self.action_space.low)
+        deterministic_action = scale_action(self.action_space, self.deterministic_action)
         return policy.obs_ph, self.actions_ph, deterministic_action
 
     def setup_model(self):
@@ -519,7 +519,7 @@ class SAC(OffPolicyRLModel):
         observation = observation.reshape((-1,) + self.observation_space.shape)
         actions = self.policy_tf.step(observation, deterministic=deterministic)
         actions = actions.reshape((-1,) + self.action_space.shape)  # reshape to the correct action shape
-        actions = actions * np.abs(self.action_space.low)  # scale the output for the prediction
+        actions = scale_action(self.action_space, actions) # scale the output for the prediction
 
         if not vectorized_env:
             actions = actions[0]

--- a/stable_baselines/td3/policies.py
+++ b/stable_baselines/td3/policies.py
@@ -23,7 +23,6 @@ class TD3Policy(BasePolicy):
     def __init__(self, sess, ob_space, ac_space, n_env=1, n_steps=1, n_batch=None, reuse=False, scale=False):
         super(TD3Policy, self).__init__(sess, ob_space, ac_space, n_env, n_steps, n_batch, reuse=reuse, scale=scale)
         assert isinstance(ac_space, Box), "Error: the action space must be of type gym.spaces.Box"
-        assert (np.abs(ac_space.low) == ac_space.high).all(), "Error: the action space low and high must be symmetric"
 
         self.qf1 = None
         self.qf2 = None

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -317,9 +317,9 @@ class TD3(OffPolicyRLModel):
                 # from a uniform distribution for better exploration.
                 # Afterwards, use the learned policy
                 # if random_exploration is set to 0 (normal setting)
-                if (self.num_timesteps < self.learning_starts
-                        or np.random.rand() < self.random_exploration):
-                    # No need to rescale when sampling random action
+                if self.num_timesteps < self.learning_starts or np.random.rand() < self.random_exploration:
+                    # actions sampled from action space are from range specific to the environment
+                    # but algorithm operates on tanh-squashed actions therefore simple scaling is used
                     unscaled_action = self.env.action_space.sample()
                     action = scale_action(self.action_space, unscaled_action)
                 else:

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -9,7 +9,7 @@ import tensorflow as tf
 from stable_baselines.a2c.utils import total_episode_reward_logger
 from stable_baselines.common import tf_util, OffPolicyRLModel, SetVerbosity, TensorboardWriter
 from stable_baselines.common.vec_env import VecEnv
-from stable_baselines.common.math_util import scale_action, unscale_action
+from stable_baselines.common.math_util import unscale_action, scale_action
 from stable_baselines.deepq.replay_buffer import ReplayBuffer
 from stable_baselines.ppo2.ppo2 import safe_mean, get_schedule_fn
 from stable_baselines.sac.sac import get_vars
@@ -121,7 +121,7 @@ class TD3(OffPolicyRLModel):
     def _get_pretrain_placeholders(self):
         policy = self.policy_tf
         # Rescale
-        policy_out = scale_action(self.action_space, self.policy_out)
+        policy_out = unscale_action(self.action_space, self.policy_out)
         return policy.obs_ph, self.actions_ph, policy_out
 
     def setup_model(self):
@@ -321,7 +321,7 @@ class TD3(OffPolicyRLModel):
                         or np.random.rand() < self.random_exploration):
                     # No need to rescale when sampling random action
                     rescaled_action = self.env.action_space.sample()
-                    action = unscale_action(self.action_space, rescaled_action)
+                    action = scale_action(self.action_space, rescaled_action)
                 else:
                     action = self.policy_tf.step(obs[None]).flatten()
                     # Add noise to the action, as the policy
@@ -329,7 +329,7 @@ class TD3(OffPolicyRLModel):
                     if self.action_noise is not None:
                         action = np.clip(action + self.action_noise(), -1, 1)
                     # Rescale from [-1, 1] to the correct bounds
-                    rescaled_action = scale_action(self.action_space, action)
+                    rescaled_action = unscale_action(self.action_space, action)
 
                 assert action.shape == self.env.action_space.shape
 
@@ -437,7 +437,7 @@ class TD3(OffPolicyRLModel):
             actions = np.clip(actions + self.action_noise(), -1, 1)
 
         actions = actions.reshape((-1,) + self.action_space.shape)  # reshape to the correct action shape
-        actions = scale_action(self.action_space, actions)  # scale the output for the prediction
+        actions = unscale_action(self.action_space, actions)  # scale the output for the prediction
 
         if not vectorized_env:
             actions = actions[0]

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -121,7 +121,7 @@ class TD3(OffPolicyRLModel):
     def _get_pretrain_placeholders(self):
         policy = self.policy_tf
         # Rescale
-        policy_out = self.policy_out * np.abs(self.action_space.low)
+        policy_out = scale_action(self.action_space, self.policy_out)
         return policy.obs_ph, self.actions_ph, policy_out
 
     def setup_model(self):
@@ -437,7 +437,7 @@ class TD3(OffPolicyRLModel):
             actions = np.clip(actions + self.action_noise(), -1, 1)
 
         actions = actions.reshape((-1,) + self.action_space.shape)  # reshape to the correct action shape
-        actions = actions * np.abs(self.action_space.low)  # scale the output for the prediction
+        actions = scale_action(self.action_space, actions)  # scale the output for the prediction
 
         if not vectorized_env:
             actions = actions[0]

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -320,8 +320,8 @@ class TD3(OffPolicyRLModel):
                 if (self.num_timesteps < self.learning_starts
                         or np.random.rand() < self.random_exploration):
                     # No need to rescale when sampling random action
-                    rescaled_action = self.env.action_space.sample()
-                    action = scale_action(self.action_space, rescaled_action)
+                    unscaled_action = self.env.action_space.sample()
+                    action = scale_action(self.action_space, unscaled_action)
                 else:
                     action = self.policy_tf.step(obs[None]).flatten()
                     # Add noise to the action, as the policy
@@ -329,11 +329,11 @@ class TD3(OffPolicyRLModel):
                     if self.action_noise is not None:
                         action = np.clip(action + self.action_noise(), -1, 1)
                     # Rescale from [-1, 1] to the correct bounds
-                    rescaled_action = unscale_action(self.action_space, action)
+                    unscaled_action = unscale_action(self.action_space, action)
 
                 assert action.shape == self.env.action_space.shape
 
-                new_obs, reward, done, info = self.env.step(rescaled_action)
+                new_obs, reward, done, info = self.env.step(unscaled_action)
 
                 # Store transition in the replay buffer.
                 self.replay_buffer.add(obs, action, reward, new_obs, float(done))

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -9,6 +9,7 @@ import tensorflow as tf
 from stable_baselines.a2c.utils import total_episode_reward_logger
 from stable_baselines.common import tf_util, OffPolicyRLModel, SetVerbosity, TensorboardWriter
 from stable_baselines.common.vec_env import VecEnv
+from stable_baselines.common.math_util import scale_action, unscale_action
 from stable_baselines.deepq.replay_buffer import ReplayBuffer
 from stable_baselines.ppo2.ppo2 import safe_mean, get_schedule_fn
 from stable_baselines.sac.sac import get_vars
@@ -319,7 +320,8 @@ class TD3(OffPolicyRLModel):
                 if (self.num_timesteps < self.learning_starts
                         or np.random.rand() < self.random_exploration):
                     # No need to rescale when sampling random action
-                    rescaled_action = action = self.env.action_space.sample()
+                    rescaled_action = self.env.action_space.sample()
+                    action = unscale_action(self.action_space, rescaled_action)
                 else:
                     action = self.policy_tf.step(obs[None]).flatten()
                     # Add noise to the action, as the policy
@@ -327,7 +329,7 @@ class TD3(OffPolicyRLModel):
                     if self.action_noise is not None:
                         action = np.clip(action + self.action_noise(), -1, 1)
                     # Rescale from [-1, 1] to the correct bounds
-                    rescaled_action = action * np.abs(self.action_space.low)
+                    rescaled_action = scale_action(self.action_space, action)
 
                 assert action.shape == self.env.action_space.shape
 

--- a/tests/test_action_scaling.py
+++ b/tests/test_action_scaling.py
@@ -9,8 +9,10 @@ ROLLOUT_STEPS = 100
 
 MODEL_LIST = [
     (DDPG, dict(nb_train_steps=0, nb_rollout_steps=ROLLOUT_STEPS)),
-    (TD3, dict(train_freq=ROLLOUT_STEPS + 1)),
-    (SAC, dict(train_freq=ROLLOUT_STEPS + 1))
+    (TD3, dict(train_freq=ROLLOUT_STEPS + 1, learning_starts=0)),
+    (SAC, dict(train_freq=ROLLOUT_STEPS + 1, learning_starts=0)),
+    (TD3, dict(train_freq=ROLLOUT_STEPS + 1, learning_starts=ROLLOUT_STEPS)),
+    (SAC, dict(train_freq=ROLLOUT_STEPS + 1, learning_starts=ROLLOUT_STEPS))
 ]
 
 

--- a/tests/test_action_scaling.py
+++ b/tests/test_action_scaling.py
@@ -29,7 +29,7 @@ def test_buffer_actions_scaling(model_class, model_kwargs):
     # check random and inferred actions as they possibly have different flows
     for random_coeff in [0.0, 1.0]:
 
-        env = DummyVecEnv([lambda: IdentityEnvBox(-1000, 1000)])
+        env = IdentityEnvBox(-2000, 1000)
 
         model = model_class("MlpPolicy", env, seed=1, random_exploration=random_coeff, **model_kwargs)
         model.learn(total_timesteps=ROLLOUT_STEPS)

--- a/tests/test_action_scaling.py
+++ b/tests/test_action_scaling.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+
+from stable_baselines import DDPG, TD3, SAC
+from stable_baselines.common.identity_env import IdentityEnvBox
+from stable_baselines.common.vec_env import DummyVecEnv
+
+ROLLOUT_STEPS = 100
+
+MODEL_LIST = [
+    (DDPG, dict(nb_train_steps=0, nb_rollout_steps=ROLLOUT_STEPS)),
+    (TD3, dict(train_freq=ROLLOUT_STEPS + 1)),
+    (SAC, dict(train_freq=ROLLOUT_STEPS + 1))
+]
+
+
+@pytest.mark.parametrize("model_class, model_kwargs", MODEL_LIST)
+def test_random_actions_scaling(model_class, model_kwargs):
+    """
+    Test if random actions are scaled to tanh co-domain before being put in a buffer
+    for algorithms that use tanh-squashing, i.e., DDPG, TD3, SAC
+
+    :param model_class: (BaseRLModel) A RL Model
+    :param model_kwargs: (dict) Dictionary containing named arguments to the given algorithm
+    """
+    env = DummyVecEnv([lambda: IdentityEnvBox(-1000, 1000)])
+
+    model = model_class("MlpPolicy", env, seed=1, random_exploration=1., **model_kwargs)
+    model.learn(total_timesteps=ROLLOUT_STEPS)
+
+    assert hasattr(model, 'replay_buffer')
+
+    buffer = model.replay_buffer
+
+    assert buffer.can_sample(ROLLOUT_STEPS)
+
+    _, actions, _, _, _ = buffer.sample(ROLLOUT_STEPS)
+
+    assert not np.any(actions > np.ones_like(actions))
+    assert not np.any(actions < -np.ones_like(actions))

--- a/tests/test_action_scaling.py
+++ b/tests/test_action_scaling.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from stable_baselines import DDPG, TD3, SAC
 from stable_baselines.common.identity_env import IdentityEnvBox
-from stable_baselines.common.vec_env import DummyVecEnv
 
 ROLLOUT_STEPS = 100
 

--- a/tests/test_math_util.py
+++ b/tests/test_math_util.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 import numpy as np
 from gym.spaces.box import Box
 
@@ -62,3 +63,16 @@ def check_scaled_actions_from_range(low, high, scalar=False):
     for (not_scaled, scaled) in expected_mapping:
         assert np.allclose(scale_action(action_space, not_scaled), scaled)
         assert np.allclose(unscale_action(action_space, scaled), not_scaled)
+
+def test_batch_shape_invariant_to_scaling():
+
+    action_space = Box(np.array([-10., -5., -1.]), np.array([10., 3., 2.]))
+
+    tensor = tf.constant(1., shape=[2, 3])
+    matrix = np.ones((2, 3))
+
+    assert scale_action(action_space, tensor).shape == (2, 3)
+    assert scale_action(action_space, matrix).shape == (2, 3)
+
+    assert unscale_action(action_space, tensor).shape == (2, 3)
+    assert unscale_action(action_space, matrix).shape == (2, 3)

--- a/tests/test_math_util.py
+++ b/tests/test_math_util.py
@@ -64,6 +64,7 @@ def check_scaled_actions_from_range(low, high, scalar=False):
         assert np.allclose(scale_action(action_space, not_scaled), scaled)
         assert np.allclose(unscale_action(action_space, scaled), not_scaled)
 
+
 def test_batch_shape_invariant_to_scaling():
     """
     test that scaling deals well with batches as tensors and numpy matrices in terms of shape

--- a/tests/test_math_util.py
+++ b/tests/test_math_util.py
@@ -34,7 +34,7 @@ def test_scaling_action():
     for (r1_low, r1_high) in test_ranges:
         for (r2_low, r2_high) in test_ranges:
             check_scaled_actions_from_range(np.array([r1_low, r2_low], dtype=np.float),
-                                    np.array([r1_high, r2_high], dtype=np.float))
+                                            np.array([r1_high, r2_high], dtype=np.float))
 
 
 def check_scaled_actions_from_range(low, high, scalar=False):

--- a/tests/test_math_util.py
+++ b/tests/test_math_util.py
@@ -65,7 +65,9 @@ def check_scaled_actions_from_range(low, high, scalar=False):
         assert np.allclose(unscale_action(action_space, scaled), not_scaled)
 
 def test_batch_shape_invariant_to_scaling():
-
+    """
+    test that scaling deals well with batches as tensors and numpy matrices in terms of shape
+    """
     action_space = Box(np.array([-10., -5., -1.]), np.array([10., 3., 2.]))
 
     tensor = tf.constant(1., shape=[2, 3])

--- a/tests/test_math_util.py
+++ b/tests/test_math_util.py
@@ -1,6 +1,7 @@
 import numpy as np
+from gym.spaces.box import Box
 
-from stable_baselines.common.math_util import discount_with_boundaries
+from stable_baselines.common.math_util import discount_with_boundaries, scale_action, unscale_action
 
 
 def test_discount_with_boundaries():
@@ -13,3 +14,51 @@ def test_discount_with_boundaries():
     discounted_rewards = discount_with_boundaries(rewards, episode_starts, gamma)
     assert np.allclose(discounted_rewards, [1 + gamma * 2 + gamma ** 2 * 3, 2 + gamma * 3, 3, 4])
     return
+
+
+def test_scaling_action():
+    """
+    test scaling of scalar, 1d and 2d vectors of finite non-NaN real numbers to and from tanh co-domain (per component)
+    """
+    test_ranges = [(-1, 1), (-10, 10), (-10, 5), (-10, 0), (-10, -5), (0, 10), (5, 10)]
+
+    # scalars
+    for (range_low, range_high) in test_ranges:
+        check_scaled_actions_from_range(range_low, range_high, scalar=True)
+
+    # 1d vectors: wrapped scalars
+    for test_range in test_ranges:
+        check_scaled_actions_from_range(*test_range)
+
+    # 2d vectors: all combinations of ranges above
+    for (r1_low, r1_high) in test_ranges:
+        for (r2_low, r2_high) in test_ranges:
+            check_scaled_actions_from_range(np.array([r1_low, r2_low], dtype=np.float),
+                                    np.array([r1_high, r2_high], dtype=np.float))
+
+
+def check_scaled_actions_from_range(low, high, scalar=False):
+    """
+    helper method which creates dummy action space spanning between respective components of low and high
+    and then checks scaling to and from tanh co-domain for low, middle and high value from  that action space
+    :param low: (np.ndarray), (int) or (float)
+    :param high: (np.ndarray), (int) or (float)
+    :param scalar: (bool) Whether consider scalar range or wrap it into 1d vector
+    """
+
+    if scalar and (isinstance(low, float) or isinstance(low, int)):
+        ones = 1.
+        action_space = Box(low, high, shape=(1,))
+    else:
+        low = np.atleast_1d(low)
+        high = np.atleast_1d(high)
+        ones = np.ones_like(low)
+        action_space = Box(low, high)
+
+    mid = 0.5 * (low + high)
+
+    expected_mapping = [(low, -ones), (mid, 0. * ones), (high, ones)]
+
+    for (not_scaled, scaled) in expected_mapping:
+        assert np.allclose(scale_action(action_space, not_scaled), scaled)
+        assert np.allclose(unscale_action(action_space, scaled), not_scaled)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Ensuring that warmup and random actions are tanh co-domain normalized before ending up in a replay buffer. Applicable to DDPG, TD3 and SAC.

## Description
<!--- Describe your changes in detail -->
I introduced 2 action-scaling functions written originally by @araffin. They were put in `stable_baselines/common/misc_util.py` as I believe that classes of `stable_baselines/common/base_class.py` have already too many responsibilities.

I introduced 3 tests: 2 in `tests/test_math_util.py` for numeric and shape testing and 1 in a new file `tests/test_action_scaling.py` parametrized by algorithm and its kwargs in order to check what ends up in the buffer under different flows. The latter test also checks inferred actions (in the same run) just to be safe. If executed on master it fails in all 5 parametrization instances.

Inside of the DDPG, TD3 and SAC algorithms I also changed all other instances of ad-hoc scaling I managed to find, in order to make things consistent. Not that I like wide-spread changes but it felt awkward to leave 2 ways of doing the same thing. This has additional advantages that a) code is not duplicated across algorithms and b) actions are no longer limited to ranges symmetric around zero. At the same time, I didn't touch asserts enforcing this symmetry as I wasn't sure if I am aware of all consequences. There are a few such asserts in the mentioned algorithms and policies.

In my setup, there were 27 fails in `pytest` before I started work. Checked twice on Ubuntu 18.04, TF 1.14. I made sure that this number didn't increase due to the addition of 3 new tests, but I didn't ponder too much on others. I run those 3 tests in separation as well.

Similarly `pytype` was failing for me when executed on the root directory of master. Therefore after adding changes, I executed `pytype` on each of the 3 algorithm directories I touched. All were fine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)

closes #573 
improves #102 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass.  (**Please refer to the description**).

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
