### PR TITLE
changed the img[0] to img.

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -632,4 +632,4 @@ Bonus: Make a GIF of a Trained Agent
       obs, _, _ ,_ = model.env.step(action)
       img = model.env.render(mode='rgb_array')
 
-  imageio.mimsave('lander_a2c.gif', [np.array(img[0]) for i, img in enumerate(images) if i%2 == 0], fps=29)
+  imageio.mimsave('lander_a2c.gif', [np.array(img) for i, img in enumerate(images) if i%2 == 0], fps=29)


### PR DESCRIPTION
In this example, images are a list of the image rendered in the environment, and here we should use **img** instead of **img[0]** which is 3 (the RGB channels). Using img[0] will make a wrong GIF file.
