### PR TITLE
Fix gif example in the doc

### DIFF
--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -632,4 +632,4 @@ Bonus: Make a GIF of a Trained Agent
       obs, _, _ ,_ = model.env.step(action)
       img = model.env.render(mode='rgb_array')
 
-  imageio.mimsave('lander_a2c.gif', [np.array(img[0]) for i, img in enumerate(images) if i%2 == 0], fps=29)
+  imageio.mimsave('lander_a2c.gif', [np.array(img) for i, img in enumerate(images) if i%2 == 0], fps=29)

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -44,6 +44,7 @@ Others:
 
 Documentation:
 ^^^^^^^^^^^^^^
+- Fixed example for creating a GIF (@KuKuXia)
 
 
 Release 2.9.0 (2019-12-20)
@@ -610,4 +611,4 @@ Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk
 @XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214 @yutingsz @sc420 @Aaahh @billtubbs
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
-@flodorner
+@flodorner @KuKuXia


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hi,
In this example, images are a list of the image rendered in the environment, and here we should use img instead of img[0] which is 3 ( the RGB channels). Using img[0] will make a wrong GIF file. 

I've run and debugged this example several times, and I think the enumerate operation is the key to this problem. My final result is to change the img[0] to img. 

Thought the environment will be a VecEnv (because created automatically in the constructor) so render will return a list of images, the enumerate operation will make it be an image again.

Details of the variables:
images: 350 * 400 * 600 * 3
img: 400  * 600 * 3
img[0]: 3 

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes) [issue 626](https://github.com/hill-a/stable-baselines/issues/625)

closes #625 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [x] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have ensured `pytest` and `pytype` both pass.

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
