### PR TITLE
Fix seeding for vectorized environments and BaseRLModel

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -16,6 +16,7 @@ New Features:
 ^^^^^^^^^^^^^
 - Parallelized updating and sampling from the replay buffer in DQN. (@flodorner)
 - Docker build script, `scripts/build_docker.sh`, can push images automatically.
+- Added a seeding method for vectorized environments. (@NeoExtended)
 
 Bug Fixes:
 ^^^^^^^^^^
@@ -33,6 +34,7 @@ Bug Fixes:
     `self.runner` instead of reinitializing a new Runner every time `learn()` is called.
 - Fixed a bug in `check_env` where it would fail on high dimensional action spaces
 - Fixed `Monitor.close()` that was not calling the parent method
+- Fixed a bug in `BaseRLModel` when seeding vectorized environments. (@NeoExtended)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -614,4 +614,4 @@ Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk
 @XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214 @yutingsz @sc420 @Aaahh @billtubbs
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
-@flodorner @KuKuXia
+@flodorner @KuKuXia @NeoExtended

--- a/stable_baselines/common/base_class.py
+++ b/stable_baselines/common/base_class.py
@@ -179,12 +179,7 @@ class BaseRLModel(ABC):
         # Seed python, numpy and tf random generator
         set_global_seeds(seed)
         if self.env is not None:
-            if isinstance(self.env, VecEnv):
-                # Use a different seed for each env
-                for idx in range(self.env.num_envs):
-                    self.env.env_method("seed", seed + idx)
-            else:
-                self.env.seed(seed)
+            self.env.seed(seed)
             # Seed the action space
             # useful when selecting random actions
             self.env.action_space.seed(seed)

--- a/stable_baselines/common/vec_env/base_vec_env.py
+++ b/stable_baselines/common/vec_env/base_vec_env.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 import inspect
 import pickle
-from typing import Sequence
+from typing import Sequence, Optional, List, Union
 
 import cloudpickle
 import numpy as np
@@ -128,13 +128,14 @@ class VecEnv(ABC):
         pass
 
     @abstractmethod
-    def seed(self, seed=None):
+    def seed(self, seed: Optional[int] = None) -> List[Union[None, int]]:
         """
         Sets the random seeds for all environments, based on a given seed.
         Each individual environment will still get its own seed, by incrementing the given seed.
 
         :param seed: (int) The random seed. May be None for completely random seeding.
-        :return: (list) Returns a list containing the seeds for each individual env.
+        :return: (list) Returns a list containing the seeds for each individual env. Note that all list elements may
+            be None, if the env does not return anything when being seeded.
         """
         pass
 

--- a/stable_baselines/common/vec_env/base_vec_env.py
+++ b/stable_baselines/common/vec_env/base_vec_env.py
@@ -133,9 +133,9 @@ class VecEnv(ABC):
         Sets the random seeds for all environments, based on a given seed.
         Each individual environment will still get its own seed, by incrementing the given seed.
 
-        :param seed: (int) The random seed. May be None for completely random seeding.
-        :return: (list) Returns a list containing the seeds for each individual env. Note that all list elements may
-            be None, if the env does not return anything when being seeded.
+        :param seed: (Optional[int]) The random seed. May be None for completely random seeding.
+        :return: (List[Union[None, int]]) Returns a list containing the seeds for each individual env.
+            Note that all list elements may be None, if the env does not return anything when being seeded.
         """
         pass
 

--- a/stable_baselines/common/vec_env/base_vec_env.py
+++ b/stable_baselines/common/vec_env/base_vec_env.py
@@ -127,6 +127,17 @@ class VecEnv(ABC):
         """
         pass
 
+    @abstractmethod
+    def seed(self, seed=None):
+        """
+        Sets the random seeds for all environments, based on a given seed.
+        Each individual environment will still get its own seed, by incrementing the given seed.
+
+        :param seed: (int) The random seed. May be None for completely random seeding.
+        :return: (list) Returns a list containing the seeds for each individual env.
+        """
+        pass
+
     def step(self, actions):
         """
         Step the environments with the given action
@@ -224,6 +235,9 @@ class VecEnvWrapper(VecEnv):
     @abstractmethod
     def step_wait(self):
         pass
+
+    def seed(self, seed=None):
+        return self.venv.seed(seed)
 
     def close(self):
         return self.venv.close()

--- a/stable_baselines/common/vec_env/dummy_vec_env.py
+++ b/stable_baselines/common/vec_env/dummy_vec_env.py
@@ -48,6 +48,12 @@ class DummyVecEnv(VecEnv):
         return (self._obs_from_buf(), np.copy(self.buf_rews), np.copy(self.buf_dones),
                 self.buf_infos.copy())
 
+    def seed(self, seed=None):
+        seeds = list()
+        for idx, env in enumerate(self.envs):
+            seeds.append(env.seed(seed + idx))
+        return seeds
+
     def reset(self):
         for env_idx in range(self.num_envs):
             obs = self.envs[env_idx].reset()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added a seed method to the base VecEnv class along with their implementations in SubprocVecEnv and DummyVecEnv. The new method is now automatically called in BaseRLModel when setting the seed.

## Motivation and Context
closes #675 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
