### PR TITLE
Check Action Type

### DIFF
--- a/stable_baselines/common/vec_env/base_vec_env.py
+++ b/stable_baselines/common/vec_env/base_vec_env.py
@@ -146,6 +146,7 @@ class VecEnv(ABC):
         :param actions: ([int] or [float]) the action
         :return: ([int] or [float], [float], [bool], dict) observation, reward, done, information
         """
+        assert isinstance( actions, ( list, np.ndarray ) ), "Action must be of type list or np.ndarray. Try wrapping your action variable in a list [ ] to fix this issue."
         self.step_async(actions)
         return self.step_wait()
 


### PR DESCRIPTION
https://github.com/hill-a/stable-baselines/issues/707

## Description
`TypeError: 'int' object is not subscriptable`
Ran a couple time into this bug, and found it really hard to debug within stable baselines.
To spare others (as well as my future self) much frustration I would suggest to add a type check to wrapper envs like dummyEnv (or only check_env?) before using the action to make sure it's an iterable, before continuing with the code.

The following assertion will give a developer friendly error message that's easy to understand and offers an immediate solution, saving much frustration.

## Motivation and Context
https://github.com/hill-a/stable-baselines/issues/707
- [x] I have raised an issue to propose this change

## Types of changes
- [x] New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).