### PR TITLE
Fix TRPO adv standardization when std is 0.

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -22,16 +22,16 @@ Breaking Changes:
 
    - Algorithms no longer import from each other, and ``common`` does not import from algorithms.
    - ``a2c/utils.py`` removed and split into other files:
-      
-      - common/tf_util.py: ``sample``, ``calc_entropy``, ``mse``, ``avg_norm``, ``total_episode_reward_logger``, 
-        ``q_explained_variance``, ``gradient_add``, ``avg_norm``, ``check_shape``, 
+
+      - common/tf_util.py: ``sample``, ``calc_entropy``, ``mse``, ``avg_norm``, ``total_episode_reward_logger``,
+        ``q_explained_variance``, ``gradient_add``, ``avg_norm``, ``check_shape``,
         ``seq_to_batch``, ``batch_to_seq``.
       - common/tf_layers.py: ``conv``, ``linear``, ``lstm``, ``_ln``, ``lnlstm``, ``conv_to_fc``, ``ortho_init``.
       - a2c/a2c.py: ``discount_with_dones``.
       - acer/acer_simple.py: ``get_by_index``, ``EpisodeStats``.
       - common/schedules.py: ``constant``, ``linear_schedule``, ``middle_drop``, ``double_linear_con``, ``double_middle_drop``,
         ``SCHEDULES``, ``Scheduler``.
-   
+
    - ``trpo_mpi/utils.py`` functions moved (``traj_segment_generator`` moved to ``common/runners.py``, ``flatten_lists`` to ``common/misc_util.py``).
    - ``ppo2/ppo2.py`` functions moved (``safe_mean`` to ``common/math_util.py``, ``constfn`` and ``get_schedule_fn`` to ``common/schedules.py``).
    - ``sac/policies.py`` function ``mlp`` moved to ``common/tf_layers.py``.
@@ -69,6 +69,7 @@ Bug Fixes:
 - Fixed a bug in ``BaseRLModel`` when seeding vectorized environments. (@NeoExtended)
 - Fixed ``num_timesteps`` computation to be consistent between algorithms (updated after ``env.step()``)
   Only ``TRPO`` and ``PPO1`` update it differently (after synchronization) because they rely on MPI
+- Fixed bug in ``TRPO`` with NaN standardized advantages (@richardwu)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -340,7 +340,7 @@ class TRPO(ActorCriticRLModel):
 
 
                         vpredbefore = seg["vpred"]  # predicted value function before update
-                        atarg = (atarg - atarg.mean()) / (atarg.std() or 1.)  # standardized advantage function estimate
+                        atarg = (atarg - atarg.mean()) / (atarg.std() + 1e-8)  # standardized advantage function estimate
 
                         # true_rew is the reward without discount
                         if writer is not None:

--- a/stable_baselines/trpo_mpi/trpo_mpi.py
+++ b/stable_baselines/trpo_mpi/trpo_mpi.py
@@ -340,7 +340,7 @@ class TRPO(ActorCriticRLModel):
 
 
                         vpredbefore = seg["vpred"]  # predicted value function before update
-                        atarg = (atarg - atarg.mean()) / atarg.std()  # standardized advantage function estimate
+                        atarg = (atarg - atarg.mean()) / (atarg.std() or 1.)  # standardized advantage function estimate
 
                         # true_rew is the reward without discount
                         if writer is not None:


### PR DESCRIPTION
## Description
If the batch of advantages has std = 0, then we default to the mean normalized values (i.e. all 0s).

## Motivation and Context
This can occur in some edge cases such as when lambda = 1 and a batch of actions lead to no per-step rewards (such that values = GAE at last timestep of batch). Ran into this within the Breakout-v0 environment.
- [ ] I have raised an issue to propose this change (required for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).