### PR TITLE
Add momentum parameter to A2C

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -14,6 +14,7 @@ Breaking Changes:
 
 New Features:
 ^^^^^^^^^^^^^
+- Added momentum parameter to A2C for the embedded RMSPropOptimizer (@kantneel)
 
 Bug Fixes:
 ^^^^^^^^^^

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -44,6 +44,7 @@ class A2C(ActorCriticRLModel):
     :param max_grad_norm: (float) The maximum value for the gradient clipping
     :param learning_rate: (float) The learning rate
     :param alpha: (float)  RMSProp decay parameter (default: 0.99)
+    :param momentum: (float) RMSProp momentum parameter (default: 0.9)
     :param epsilon: (float) RMSProp epsilon (stabilizes square root computation in denominator of RMSProp update)
         (default: 1e-5)
     :param lr_schedule: (str) The type of scheduler for the learning rate update ('linear', 'constant',
@@ -63,8 +64,8 @@ class A2C(ActorCriticRLModel):
     """
 
     def __init__(self, policy, env, gamma=0.99, n_steps=5, vf_coef=0.25, ent_coef=0.01, max_grad_norm=0.5,
-                 learning_rate=7e-4, alpha=0.99, epsilon=1e-5, lr_schedule='constant', verbose=0,
-                 tensorboard_log=None, _init_setup_model=True, policy_kwargs=None,
+                 learning_rate=7e-4, alpha=0.99, momentum=0.9, epsilon=1e-5, lr_schedule='constant',
+                 verbose=0, tensorboard_log=None, _init_setup_model=True, policy_kwargs=None,
                  full_tensorboard_log=False, seed=None, n_cpu_tf_sess=None):
 
         self.n_steps = n_steps
@@ -73,6 +74,7 @@ class A2C(ActorCriticRLModel):
         self.ent_coef = ent_coef
         self.max_grad_norm = max_grad_norm
         self.alpha = alpha
+        self.momentum = momentum
         self.epsilon = epsilon
         self.lr_schedule = lr_schedule
         self.learning_rate = learning_rate
@@ -180,7 +182,7 @@ class A2C(ActorCriticRLModel):
                             tf.summary.histogram('observation', train_model.obs_ph)
 
                 trainer = tf.train.RMSPropOptimizer(learning_rate=self.learning_rate_ph, decay=self.alpha,
-                                                    epsilon=self.epsilon)
+                                                    epsilon=self.epsilon, momentum=self.momentum)
                 self.apply_backprop = trainer.apply_gradients(grads)
 
                 self.train_model = train_model

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -44,7 +44,7 @@ class A2C(ActorCriticRLModel):
     :param max_grad_norm: (float) The maximum value for the gradient clipping
     :param learning_rate: (float) The learning rate
     :param alpha: (float)  RMSProp decay parameter (default: 0.99)
-    :param momentum: (float) RMSProp momentum parameter (default: 0.9)
+    :param momentum: (float) RMSProp momentum parameter (default: 0.0)
     :param epsilon: (float) RMSProp epsilon (stabilizes square root computation in denominator of RMSProp update)
         (default: 1e-5)
     :param lr_schedule: (str) The type of scheduler for the learning rate update ('linear', 'constant',
@@ -64,7 +64,7 @@ class A2C(ActorCriticRLModel):
     """
 
     def __init__(self, policy, env, gamma=0.99, n_steps=5, vf_coef=0.25, ent_coef=0.01, max_grad_norm=0.5,
-                 learning_rate=7e-4, alpha=0.99, momentum=0.9, epsilon=1e-5, lr_schedule='constant',
+                 learning_rate=7e-4, alpha=0.99, momentum=0.0, epsilon=1e-5, lr_schedule='constant',
                  verbose=0, tensorboard_log=None, _init_setup_model=True, policy_kwargs=None,
                  full_tensorboard_log=False, seed=None, n_cpu_tf_sess=None):
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I was using the A2C class to reimplement a paper and found that I could not change the momentum parameter used inside the RMSPropOptimizer here:
https://github.com/hill-a/stable-baselines/blob/master/stable_baselines/a2c/a2c.py#L182

I remedied this by adding a parameter to the constructor and applied it where necessary, using the same patterns as those used for the other optimizer args. Because of those arguments to the constructor (epsilon, alpha), I did not see the point of creating new tests. If you have ideas for meaningful tests, please let me know.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [x] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)
Closes #747 .


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)

