### PR TITLE
Correct time to update checking in SAC/TD3

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,7 +18,7 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Fixed DDPG sampling empty replay buffer when combined with HER  (@tirafesi)
-
+- Fixed SAC checking time to update on learn steps instead of total steps (@solliet)
 Deprecations:
 ^^^^^^^^^^^^^
 

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes:
 ^^^^^^^^^^
 - Fixed DDPG sampling empty replay buffer when combined with HER  (@tirafesi)
 - Fixed SAC checking time to update on learn steps instead of total steps (@solliet)
+- Fixed TD3 checking time to update on learn steps instead of total steps (@solliet)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,8 +18,7 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Fixed DDPG sampling empty replay buffer when combined with HER  (@tirafesi)
-- Fixed SAC checking time to update on learn steps instead of total steps (@solliet)
-- Fixed TD3 checking time to update on learn steps instead of total steps (@solliet)
+- Fixed SAC/TD3 checking time to update on learn steps instead of total steps (@solliet)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -19,6 +19,7 @@ Bug Fixes:
 ^^^^^^^^^^
 - Fixed DDPG sampling empty replay buffer when combined with HER  (@tirafesi)
 - Fixed SAC checking time to update on learn steps instead of total steps (@solliet)
+
 Deprecations:
 ^^^^^^^^^^^^^
 

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -445,7 +445,7 @@ class SAC(OffPolicyRLModel):
                     tf_util.total_episode_reward_logger(self.episode_reward, ep_reward,
                                                         ep_done, writer, self.num_timesteps)
 
-                if step % self.train_freq == 0:
+                if self.num_timesteps % self.train_freq == 0:
                     callback.on_rollout_end()
 
                     mb_infos_vals = []

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -364,7 +364,7 @@ class TD3(OffPolicyRLModel):
                     tf_util.total_episode_reward_logger(self.episode_reward, ep_reward,
                                                         ep_done, writer, self.num_timesteps)
 
-                if step % self.train_freq == 0:
+                if self.num_timesteps % self.train_freq == 0:
                     callback.on_rollout_end()
 
                     mb_infos_vals = []


### PR DESCRIPTION
## Description
Corrected minor bug in sac where train_freq was compared to local variable `step` instead of `agent.num_timesteps` in order to check if it was time to update.

## Motivation and Context
Running `agent.learn` with total_timesteps less than the update frequency resulted in no policy updates.

* [x]  I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)
        Closes #754 .

## Types of changes

  * [x]  Bug fix (non-breaking change which fixes an issue)
  * [ ]  New feature (non-breaking change which adds functionality)
  * [ ]  Breaking change (fix or feature that would cause existing functionality to change)
  * [ ]  Documentation (update in the documentation)

## Checklist:

  * [x] I've read the CONTRIBUTION guide (required)
  * [x] I have updated the changelog accordingly (required).
  * [ ] My change requires a change to the documentation.
  * [ ] I have updated the tests accordingly (required for a bug fix or a new feature).
  * [ ]  I have updated the documentation accordingly.
  * [ ] I have ensured pytest and pytype both pass (by running make pytest and make type).