### PR TITLE
Fix reward threshold in `test_identity.py`

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -22,6 +22,7 @@ Bug Fixes:
 - Fixed SAC/TD3 checking time to update on learn steps instead of total steps (@solliet)
 - Added ``**kwarg`` pass through for ``reset`` method in ``atari_wrappers.FrameStack`` (@solliet)
 - Fix consistency in ``setup_model()`` for SAC, ``target_entropy`` now uses ``self.action_space`` instead of ``self.env.action_space`` (@solliet)
+- Fix reward threshold in ``test_identity.py``
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -39,7 +39,7 @@ def test_identity(model_name):
     env = DummyVecEnv([lambda: IdentityEnv(10)])
 
     model = LEARN_FUNC_DICT[model_name](env)
-    evaluate_policy(model, env, n_eval_episodes=20, reward_threshold=0.9)
+    evaluate_policy(model, env, n_eval_episodes=20, reward_threshold=90)
 
     obs = env.reset()
     assert model.action_probability(obs).shape == (1, 10), "Error: action_probability not returning correct shape"
@@ -72,6 +72,6 @@ def test_identity_continuous(model_class):
                          action_noise=action_noise, buffer_size=int(1e6))
     model.learn(total_timesteps=20000)
 
-    evaluate_policy(model, env, n_eval_episodes=20, reward_threshold=0.9)
+    evaluate_policy(model, env, n_eval_episodes=20, reward_threshold=90)
     # Free memory
     del model, env


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
The reward threshold was incorrectly specify in percent (it was incorrect since the introduction of `evaluate_policy` helper)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've written the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
