### PR TITLE
Fix PPO2 tensorboard duplicate entry

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -25,6 +25,7 @@ Bug Fixes:
 - Added ``**kwarg`` pass through for ``reset`` method in ``atari_wrappers.FrameStack`` (@solliet)
 - Fix consistency in ``setup_model()`` for SAC, ``target_entropy`` now uses ``self.action_space`` instead of ``self.env.action_space`` (@solliet)
 - Fix reward threshold in ``test_identity.py``
+- Fix tensorboard indexing for PPO2 (@enderdead)
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -25,7 +25,7 @@ Bug Fixes:
 - Added ``**kwarg`` pass through for ``reset`` method in ``atari_wrappers.FrameStack`` (@solliet)
 - Fix consistency in ``setup_model()`` for SAC, ``target_entropy`` now uses ``self.action_space`` instead of ``self.env.action_space`` (@solliet)
 - Fix reward threshold in ``test_identity.py``
-- Fix tensorboard indexing for PPO2 (@enderdead)
+- Partially fix tensorboard indexing for PPO2 (@enderdead)
 
 Deprecations:
 ^^^^^^^^^^^^^
@@ -694,3 +694,5 @@ Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @solliet @mmcenta @richardwu @tirafesi @caburu @johannes-dornheim @kvenkman @aakash94
+@enderdead
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This merge request fix the tensorboard indexing system witch was implemented in a weird way.

An example to reproduce the issue : 
```
from stable_baselines import PPO2

PPO2("MlpPolicy", "CartPole-v1", tensorboard_log="/tmp/test_v1", full_tensorboard_log=True,
    verbose=1).learn(100000)
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- You can use the syntax `closes #100` if this solves the issue #100 -->
- [X] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)


This merge request fixes an old issue (#81). This problem occurs when a label is submitted twice on the writer :
https://github.com/hill-a/stable-baselines/blob/d699d6fdeaea6db24959f63f9f0de9b357f466b6/stable_baselines/ppo2/ppo2.py#L290

The error comes from the `num_timesteps//update_fac` variable which takes the same value twice. The main reason is the definition of the constante `update_fac`.

https://github.com/hill-a/stable-baselines/blob/d699d6fdeaea6db24959f63f9f0de9b357f466b6/stable_baselines/ppo2/ppo2.py#L349

If I correcly understand the purpose of this constant, it has to translate the current num_timesteps to the number of updates already done. So if we have :  n_steps=128, nminibatches=4, noptepochs=4, num_timesteps=384.
num_timesteps // update fact has to be equal to 48 because num_timesteps = 128\*3  and we have nminibatches\*noptepochs=16 gradient descent per learning phase so 3\*16=48. So far so good. 

But on 17 Nov 2018  this issue was raise #81. If we have a too large nminibatches and noptepochs the definition can be equals to 0. So you decided to add an offset #92, it's good idea but in some cases it doesn't work.

If we take the same example update fact is equal to 33 due to the +1 at the end. This causes an issue because at some point `n_steps\*k // update_fact`  will be equals to `n_steps\*(k+1) // update_fact` because `n_steps\*k %update_fact = 0` and `n_steps\*k %update_fact = n_steps`. 
The trivial fix is to use a max operator instead of an addition.

During my reserch, I found a very wierd manner to determine the current iteration. it's defined like this : 

https://github.com/hill-a/stable-baselines/blob/d699d6fdeaea6db24959f63f9f0de9b357f466b6/stable_baselines/ppo2/ppo2.py#L354-L355


This formula was introdius in the merge request :
https://github.com/hill-a/stable-baselines/pull/185

This is the previous implementation : 
```
timestep = ((update * self.noptepochs * self.n_batch + epoch_num * self.n_batch + start) //
            batch_size)

```
This modification must preserve the formula result but  it doesn't. 
If we want to associate each piece from those 2 formulae, we associete easily this one :
```
 self.num_timesteps // update_fac   = (update * self.noptepochs * self.n_batch) // batch_size
```
```
 ( epoch_num * self.n_batch + start ) //  batch_size =  (epoch_num * self.n_batch + start) // batch_size
```   
But this term does not belong to the original formula :
```
(self.noptepochs * self.n_batch) // batch_size
```  
I removed it and checked that it produced a suitable tensorboard (and it did).

An other issue still remains with this line :

https://github.com/hill-a/stable-baselines/blob/d699d6fdeaea6db24959f63f9f0de9b357f466b6/stable_baselines/ppo2/ppo2.py#L284

If you have a lot of epoch per update, let's say 10*n_steps,  `update * update_fac` will return the same result twice in a row. I didn't fix it yet, waiting your opinion  about it (do I have to make an issue ?, Do you think that it's an expected situation ?).
    
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [X] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).



<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->