### PR TITLE
Fix SAC target network parameters

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -28,6 +28,7 @@ Bug Fixes:
 - Partially fix tensorboard indexing for PPO2 (@enderdead)
 - Fixed potential bug in ``DummyVecEnv`` where ``copy()`` was used instead of ``deepcopy()``
 - Fixed a bug in ``GAIL`` where the dataloader was not available after saving, causing an error when using ``CheckpointCallback``
+- Fixed a bug in ``SAC`` where any convolutional layers were not included in the target network parameters.
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -258,8 +258,8 @@ class SAC(OffPolicyRLModel):
                     value_optimizer = tf.train.AdamOptimizer(learning_rate=self.learning_rate_ph)
                     values_params = tf_util.get_trainable_vars('model/values_fn')
 
-                    source_params = tf_util.get_trainable_vars("model/values_fn/vf")
-                    target_params = tf_util.get_trainable_vars("target/values_fn/vf")
+                    source_params = tf_util.get_trainable_vars("model/values_fn")
+                    target_params = tf_util.get_trainable_vars("target/values_fn")
 
                     # Polyak averaging for target variables
                     self.target_update_op = [
@@ -304,7 +304,7 @@ class SAC(OffPolicyRLModel):
 
                 # Retrieve parameters that must be saved
                 self.params = tf_util.get_trainable_vars("model")
-                self.target_params = tf_util.get_trainable_vars("target/values_fn/vf")
+                self.target_params = tf_util.get_trainable_vars("target/values_fn")
 
                 # Initialize Variables and target network
                 with self.sess.as_default():


### PR DESCRIPTION
Fixes issue where SAC target V-function parameters did not include e.g. convolutional layers (when using cnn).

Closes #854

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).