### PR TITLE
Fix log interval in SAC/TD3

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -37,7 +37,7 @@ Bug Fixes:
 - Fixed a bug in the ``close()`` method of ``SubprocVecEnv``, causing wrappers further down in the wrapper stack to not be closed. (@NeoExtended)
 - Fixed a bug in the ``generate_expert_traj()`` method in ``record_expert.py`` when using a non-image vectorized environment (@jbarsce)
 - Fixed a bug in CloudPickleWrapper's (used by VecEnvs) ``__setstate___`` where loading was incorrectly using ``pickle.loads`` (@shwang).
-- Fixed a bug in ``SAC`` where the log timesteps was not correct(@YangRui2015) 
+- Fixed a bug in ``SAC`` and ``TD3`` where the log timesteps was not correct(@YangRui2015) 
 
 
 Deprecations:

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -37,6 +37,7 @@ Bug Fixes:
 - Fixed a bug in the ``close()`` method of ``SubprocVecEnv``, causing wrappers further down in the wrapper stack to not be closed. (@NeoExtended)
 - Fixed a bug in the ``generate_expert_traj()`` method in ``record_expert.py`` when using a non-image vectorized environment (@jbarsce)
 - Fixed a bug in CloudPickleWrapper's (used by VecEnvs) ``__setstate___`` where loading was incorrectly using ``pickle.loads`` (@shwang).
+- Fixed a bug in ``SAC`` where the log timesteps was not correct(@YangRui2015) 
 
 
 Deprecations:
@@ -717,4 +718,4 @@ Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket
 @MarvineGothic @jdossgollin @SyllogismRXS @rusu24edward @jbulow @Antymon @seheevic @justinkterry @edbeeching
 @flodorner @KuKuXia @NeoExtended @PartiallyTyped @mmcenta @richardwu @tirafesi @caburu @johannes-dornheim @kvenkman @aakash94
-@enderdead @hardmaru @jbarsce @ColinLeongUDRI @shwang
+@enderdead @hardmaru @jbarsce @ColinLeongUDRI @shwang @YangRui2015

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -488,9 +488,9 @@ class SAC(OffPolicyRLModel):
                 else:
                     mean_reward = round(float(np.mean(episode_rewards[-101:-1])), 1)
 
-                num_episodes = len(episode_rewards)
+                num_episodes = len(episode_rewards) - 1 # as we appended a new term just now
                 # Display training infos
-                if self.verbose >= 1 and done and log_interval is not None and len(episode_rewards) % log_interval == 0:
+                if self.verbose >= 1 and done and log_interval is not None and num_episodes % log_interval == 0:
                     fps = int(step / (time.time() - start_time))
                     logger.logkv("episodes", num_episodes)
                     logger.logkv("mean 100 episode reward", mean_reward)

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -488,7 +488,8 @@ class SAC(OffPolicyRLModel):
                 else:
                     mean_reward = round(float(np.mean(episode_rewards[-101:-1])), 1)
 
-                num_episodes = len(episode_rewards) - 1 # as we appended a new term just now
+                # substract 1 as we appended a new term just now
+                num_episodes = len(episode_rewards) - 1 
                 # Display training infos
                 if self.verbose >= 1 and done and log_interval is not None and num_episodes % log_interval == 0:
                     fps = int(step / (time.time() - start_time))

--- a/stable_baselines/td3/td3.py
+++ b/stable_baselines/td3/td3.py
@@ -408,9 +408,10 @@ class TD3(OffPolicyRLModel):
                 else:
                     mean_reward = round(float(np.mean(episode_rewards[-101:-1])), 1)
 
-                num_episodes = len(episode_rewards)
+                # substract 1 as we appended a new term just now
+                num_episodes = len(episode_rewards) - 1
                 # Display training infos
-                if self.verbose >= 1 and done and log_interval is not None and len(episode_rewards) % log_interval == 0:
+                if self.verbose >= 1 and done and log_interval is not None and num_episodes % log_interval == 0:
                     fps = int(step / (time.time() - start_time))
                     logger.logkv("episodes", num_episodes)
                     logger.logkv("mean 100 episode reward", mean_reward)


### PR DESCRIPTION
### Description

This PR is for fixing the bug in the issue #958 [minor bug of log in sac.py ](https://github.com/hill-a/stable-baselines/issues/958).

closes #958 

### Motivation and Context

**Bug**: The last step of one episode was labeled as the first step of the next episode because we add 0 in the episode_rewards before log. In the following picture, we expect log at 20 episodes (20 * 50 steps), however it log as the end of 19 episode. To fix it, we can easily subtract 1 to label it as the 19th episode.
(I printed steps, num_episode,  and done using:  `print(step, num_episodes, done)`)
![截屏2020-07-23 上午10 37 27](https://user-images.githubusercontent.com/38036768/88249298-a5813f00-ccd6-11ea-84b5-3ec6fd590318.png)

### Types of changes

  

- [x] Bug fix (non-breaking change which fixes an issue)

  
- [ ] New feature (non-breaking change which adds functionality)

 
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

 
- [ ] Documentation (update in the documentation)

### Checklist:

 
- [x]  I've read the CONTRIBUTION guide (required)

 
- [x]  I have updated the changelog accordingly (required).

 
- [ ]  My change requires a change to the documentation.

  
- [ ] I have updated the tests accordingly (required for a bug fix or a new feature).


- [ ]  I have updated the documentation accordingly.

- [ ]   I have ensured pytest and pytype both pass.





