### PR TITLE
Fixed step used to log SAC summary

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -65,7 +65,7 @@ Bug Fixes:
 - Fixed a bug in CloudPickleWrapper's (used by VecEnvs) ``__setstate___`` where loading was incorrectly using ``pickle.loads`` (@shwang).
 - Fixed a bug in ``SAC`` and ``TD3`` where the log timesteps was not correct(@YangRui2015)
 - Fixed a bug where the environment was reset twice when using ``evaluate_policy``
-
+- Fixed a bug where ``SAC`` uses wrong step to log to tensorboard after multiple calls to ``SAC.learn(..., reset_num_timesteps=True)``
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines/sac/sac.py
+++ b/stable_baselines/sac/sac.py
@@ -314,6 +314,7 @@ class SAC(OffPolicyRLModel):
                 self.summary = tf.summary.merge_all()
 
     def _train_step(self, step, writer, learning_rate):
+        del step
         # Sample a batch from the replay buffer
         batch = self.replay_buffer.sample(self.batch_size, env=self._vec_normalize_env)
         batch_obs, batch_actions, batch_rewards, batch_next_obs, batch_dones = batch
@@ -336,7 +337,7 @@ class SAC(OffPolicyRLModel):
         if writer is not None:
             out = self.sess.run([self.summary] + self.step_ops, feed_dict)
             summary = out.pop(0)
-            writer.add_summary(summary, step)
+            writer.add_summary(summary, self.num_timesteps)
         else:
             out = self.sess.run(self.step_ops, feed_dict)
 


### PR DESCRIPTION
fixes hill-a#1007

Description
Changed call to writer.add_summary to use self.num_timesteps in the case that num_timesteps is not reset after multiple calls to model.learn(..., reset_num_timesteps=False).

Motivation and Context
 I have raised an issue to propose this change (required for new features and bug fixes)
Issues hill-a#1007 shows an example where tensorboard plotted line is discontinuous due to incorrect step counter
Types of changes
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)
 Documentation (update in the documentation)
Checklist:
 I've read the CONTRIBUTION guide (required)
 I have updated the changelog accordingly (required).
 My change requires a change to the documentation.
 I have updated the tests accordingly (required for a bug fix or a new feature).
 I have updated the documentation accordingly.
 I have ensured pytest and pytype both pass (by running make pytest and make type).