### PR TITLE
Make EvalCallback work for recurrent policies

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -15,6 +15,7 @@ Breaking Changes:
 
 New Features:
 ^^^^^^^^^^^^^
+- EvalCallback now works also for recurrent policies
 
 Bug Fixes:
 ^^^^^^^^^^

--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -15,7 +15,7 @@ Breaking Changes:
 
 New Features:
 ^^^^^^^^^^^^^
-- EvalCallback now works also for recurrent policies
+- EvalCallback now works also for recurrent policies (@mily20001)
 
 Bug Fixes:
 ^^^^^^^^^^
@@ -740,7 +740,7 @@ Contributors (since v2.0.0):
 ----------------------------
 In random order...
 
-Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck
+Thanks to @bjmuld @iambenzo @iandanforth @r7vme @brendenpetersen @huvar @abhiskk @JohannesAck @mily20001
 @EliasHasle @mrakgr @Bleyddyn @antoine-galataud @junhyeokahn @AdamGleave @keshaviyengar @tperol
 @XMaster96 @kantneel @Pastafarianist @GerardMaggiolino @PatrickWalter214 @yutingsz @sc420 @Aaahh @billtubbs
 @Miffyli @dwiel @miguelrass @qxcv @jaberkow @eavelardev @ruifeng96150 @pedrohbtp @srivatsankrishnan @evilsocket

--- a/stable_baselines/common/evaluation.py
+++ b/stable_baselines/common/evaluation.py
@@ -58,11 +58,11 @@ def evaluate_policy(
         episode_length = 0
         while not done:
             action, state = model.predict(obs, state=state, deterministic=deterministic)
+            new_obs, reward, done, _info = env.step(action)
             if is_recurrent:
-                new_obs, reward, done, _info = env.step(action)
                 obs[0, :] = new_obs
             else:
-                obs, reward, done, _info = env.step(action)
+                obs = new_obs
             episode_reward += reward
             if callback is not None:
                 callback(locals(), globals())

--- a/stable_baselines/common/evaluation.py
+++ b/stable_baselines/common/evaluation.py
@@ -49,6 +49,8 @@ def evaluate_policy(
         # Avoid double reset, as VecEnv are reset automatically
         if not isinstance(env, VecEnv) or i == 0:
             obs = env.reset()
+            # Because recurrent policies need the same observation space during training and evaluation, we need to pad
+            # observation to match training shape. See https://github.com/hill-a/stable-baselines/issues/1015
             if is_recurrent:
                 zero_completed_obs = np.zeros((model.n_envs,) + model.observation_space.shape)
                 zero_completed_obs[0, :] = obs

--- a/stable_baselines/common/evaluation.py
+++ b/stable_baselines/common/evaluation.py
@@ -42,17 +42,27 @@ def evaluate_policy(
     if isinstance(env, VecEnv):
         assert env.num_envs == 1, "You must pass only one environment when using this function"
 
+    is_recurrent = model.policy.recurrent
+
     episode_rewards, episode_lengths = [], []
     for i in range(n_eval_episodes):
         # Avoid double reset, as VecEnv are reset automatically
         if not isinstance(env, VecEnv) or i == 0:
             obs = env.reset()
+            if is_recurrent:
+                zero_completed_obs = np.zeros((model.n_envs,) + model.observation_space.shape)
+                zero_completed_obs[0, :] = obs
+                obs = zero_completed_obs
         done, state = False, None
         episode_reward = 0.0
         episode_length = 0
         while not done:
             action, state = model.predict(obs, state=state, deterministic=deterministic)
-            obs, reward, done, _info = env.step(action)
+            if is_recurrent:
+                new_obs, reward, done, _info = env.step(action)
+                obs[0, :] = new_obs
+            else:
+                obs, reward, done, _info = env.step(action)
             episode_reward += reward
             if callback is not None:
                 callback(locals(), globals())


### PR DESCRIPTION
Main purpose of this change is to make EvalCallback work also for recurrent policies trained on more than 1 environment, whose as for now requires the same observation space shape as during training stage

## Description
Depending on policy `recurrent` prop EvalCallback pads observations with zeros to make them compatible with training observation shape

## Motivation and Context
Closes #1015 
Implemented based on https://github.com/hill-a/stable-baselines/issues/166#issuecomment-502350843
- [x] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
