### PR TITLE
Fix re-training with different number of environments

### DIFF
--- a/docs/misc/changelog.rst
+++ b/docs/misc/changelog.rst
@@ -18,6 +18,7 @@ New Features:
 Bug Fixes:
 ^^^^^^^^^^
 - Fixed bug in pretraining method that prevented from calling it twice.
+- Fixed a bug where a crash would occur if a PPO2 model was trained in a vectorized environment, saved and subsequently loaded, then trained in a vectorized environment with a different length
 
 Deprecations:
 ^^^^^^^^^^^^^

--- a/stable_baselines/a2c/a2c.py
+++ b/stable_baselines/a2c/a2c.py
@@ -241,6 +241,10 @@ class A2C(ActorCriticRLModel):
 
         return policy_loss, value_loss, policy_entropy
 
+    def set_env(self,env):
+        super().set_env(env)
+        self.n_batch = self.n_envs * self.n_steps
+
     def learn(self, total_timesteps, callback=None, log_interval=100, tb_log_name="A2C",
               reset_num_timesteps=True):
 

--- a/stable_baselines/common/callbacks.py
+++ b/stable_baselines/common/callbacks.py
@@ -251,8 +251,8 @@ class EvalCallback(EventCallback):
                  callback_on_new_best: Optional[BaseCallback] = None,
                  n_eval_episodes: int = 5,
                  eval_freq: int = 10000,
-                 log_path: str = None,
-                 best_model_save_path: str = None,
+                 log_path: Optional[str] = None,
+                 best_model_save_path: Optional[str] = None,
                  deterministic: bool = True,
                  render: bool = False,
                  verbose: int = 1):

--- a/stable_baselines/ppo2/ppo2.py
+++ b/stable_baselines/ppo2/ppo2.py
@@ -298,7 +298,11 @@ class PPO2(ActorCriticRLModel):
                 [self.pg_loss, self.vf_loss, self.entropy, self.approxkl, self.clipfrac, self._train], td_map)
 
         return policy_loss, value_loss, policy_entropy, approxkl, clipfrac
-
+    
+    def set_env(self,env):
+        super().set_env(env)
+        self.n_batch = self.n_envs * self.n_steps
+    
     def learn(self, total_timesteps, callback=None, log_interval=1, tb_log_name="PPO2",
               reset_num_timesteps=True):
         # Transform to callable if needed

--- a/tests/test_a2c.py
+++ b/tests/test_a2c.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-import gym 
+import gym
 
 from stable_baselines import A2C
 from stable_baselines.common import make_vec_env
@@ -9,17 +9,18 @@ from stable_baselines.common.vec_env import DummyVecEnv
 
 
 def test_a2c_update_n_batch_on_load(tmp_path):
-    env = make_vec_env('CartPole-v1',n_envs=2)
-    model = A2C('MlpPolicy', env, n_steps = 10)
-    
-    model.learn(total_timesteps = 100)
-    model.save(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))
-    
+    env = make_vec_env("CartPole-v1", n_envs=2)
+    model = A2C("MlpPolicy", env, n_steps=10)
+
+    model.learn(total_timesteps=100)
+    model.save(os.path.join(str(tmp_path), "a2c_cartpole.zip"))
+
     del model
-    
-    model = A2C.load(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))
-    test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
-    
+
+    model = A2C.load(os.path.join(str(tmp_path), "a2c_cartpole.zip"))
+    test_env = DummyVecEnv([lambda: gym.make("CartPole-v1")])
+
     model.set_env(test_env)
-    assert(model.n_batch == 10)
-    os.remove(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))
+    assert model.n_batch == 10
+    model.learn(100)
+    os.remove(os.path.join(str(tmp_path), "a2c_cartpole.zip"))

--- a/tests/test_a2c.py
+++ b/tests/test_a2c.py
@@ -1,0 +1,27 @@
+import os
+import pathlib
+
+import pytest
+import gym 
+
+from stable_baselines import A2C
+from stable_baselines.common import make_vec_env
+from stable_baselines.common.vec_env import DummyVecEnv
+
+
+def test_a2c_update_n_batch_on_load(tmp_path):
+    env = make_vec_env('CartPole-v1',n_envs=2)
+    model = A2C('MlpPolicy', env, n_steps = 10)
+    
+    model.learn(total_timesteps = 100)
+    model.save(tmp_path / "a2c_cartpole.zip")
+    
+    del model
+    
+    model = A2C.load(tmp_path / "a2c_cartpole.zip")
+    test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
+    
+    model.set_env(test_env)
+    model.learn(total_timesteps = 100)
+    assert(model.n_batch == 10)
+    os.remove(tmp_path / "a2c_cartpole.zip")

--- a/tests/test_a2c.py
+++ b/tests/test_a2c.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 
 import pytest
 import gym 
@@ -14,14 +13,13 @@ def test_a2c_update_n_batch_on_load(tmp_path):
     model = A2C('MlpPolicy', env, n_steps = 10)
     
     model.learn(total_timesteps = 100)
-    model.save(tmp_path / "a2c_cartpole.zip")
+    model.save(os.path.join(tmp_path , "a2c_cartpole.zip"))
     
     del model
     
-    model = A2C.load(tmp_path / "a2c_cartpole.zip")
+    model = A2C.load(os.path.join(tmp_path , "a2c_cartpole.zip"))
     test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
     
     model.set_env(test_env)
-    model.learn(total_timesteps = 100)
     assert(model.n_batch == 10)
-    os.remove(tmp_path / "a2c_cartpole.zip")
+    os.remove(os.path.join(tmp_path , "a2c_cartpole.zip"))

--- a/tests/test_a2c.py
+++ b/tests/test_a2c.py
@@ -13,13 +13,13 @@ def test_a2c_update_n_batch_on_load(tmp_path):
     model = A2C('MlpPolicy', env, n_steps = 10)
     
     model.learn(total_timesteps = 100)
-    model.save(os.path.join(tmp_path , "a2c_cartpole.zip"))
+    model.save(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))
     
     del model
     
-    model = A2C.load(os.path.join(tmp_path , "a2c_cartpole.zip"))
+    model = A2C.load(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))
     test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
     
     model.set_env(test_env)
     assert(model.n_batch == 10)
-    os.remove(os.path.join(tmp_path , "a2c_cartpole.zip"))
+    os.remove(os.path.join(str(tmp_path) , "a2c_cartpole.zip"))

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -1,8 +1,11 @@
 import os
 
 import pytest
+import gym 
 
 from stable_baselines import PPO2
+from stable_baselines.common import make_vec_env
+from stable_baselines.common.vec_env import DummyVecEnv
 
 
 @pytest.mark.parametrize("cliprange", [0.2, lambda x: 0.1 * x])
@@ -19,3 +22,18 @@ def test_clipping(cliprange, cliprange_vf):
 
     if os.path.exists('./ppo2_clip.zip'):
         os.remove('./ppo2_clip.zip')
+
+def test_update_n_batch_on_load():
+    env = make_vec_env('CartPole-v1',n_envs=2)
+    model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
+    
+    model.learn(total_timesteps = 100)
+    model.save("ppo2_cartpole")
+    
+    del model
+    
+    model = PPO2.load("ppo2_cartpole")
+    test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
+    
+    model.set_env(test_env)
+    model.learn(total_timesteps = 100)

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -28,13 +28,13 @@ def test_ppo2_update_n_batch_on_load(tmp_path):
     model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
     
     model.learn(total_timesteps = 100)
-    model.save(os.path.join(tmp_path , "ppo2_cartpole.zip"))
+    model.save(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))
     
     del model
     
-    model = PPO2.load(os.path.join(tmp_path , "ppo2_cartpole.zip"))
+    model = PPO2.load(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))
     test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
     
     model.set_env(test_env)
     model.learn(total_timesteps = 100)
-    os.remove(os.path.join(tmp_path , "ppo2_cartpole.zip"))
+    os.remove(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -37,3 +37,5 @@ def test_update_n_batch_on_load():
     
     model.set_env(test_env)
     model.learn(total_timesteps = 100)
+    if os.path.exists('./ppo2_cartpole.zip'):
+        os.remove('./ppo2_cartpole.zip')

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 
 import pytest
 import gym 
@@ -23,19 +24,18 @@ def test_clipping(cliprange, cliprange_vf):
     if os.path.exists('./ppo2_clip.zip'):
         os.remove('./ppo2_clip.zip')
 
-def test_update_n_batch_on_load():
+def test_update_n_batch_on_load(tmp_path):
     env = make_vec_env('CartPole-v1',n_envs=2)
     model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
     
     model.learn(total_timesteps = 100)
-    model.save("ppo2_cartpole")
+    model.save(tmp_path / "ppo2_cartpole.zip")
     
     del model
     
-    model = PPO2.load("ppo2_cartpole")
+    model = PPO2.load(tmp_path / "ppo2_cartpole.zip")
     test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
     
     model.set_env(test_env)
     model.learn(total_timesteps = 100)
-    if os.path.exists('./ppo2_cartpole.zip'):
-        os.remove('./ppo2_cartpole.zip')
+    os.remove(tmp_path / "ppo2_cartpole.zip")

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 
 import pytest
 import gym 
@@ -29,13 +28,13 @@ def test_ppo2_update_n_batch_on_load(tmp_path):
     model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
     
     model.learn(total_timesteps = 100)
-    model.save(tmp_path / "ppo2_cartpole.zip")
+    model.save(os.path.join(tmp_path , "ppo2_cartpole.zip"))
     
     del model
     
-    model = PPO2.load(tmp_path / "ppo2_cartpole.zip")
+    model = PPO2.load(os.path.join(tmp_path , "ppo2_cartpole.zip"))
     test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
     
     model.set_env(test_env)
     model.learn(total_timesteps = 100)
-    os.remove(tmp_path / "ppo2_cartpole.zip")
+    os.remove(os.path.join(tmp_path , "ppo2_cartpole.zip"))

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-import gym 
+import gym
 
 from stable_baselines import PPO2
 from stable_baselines.common import make_vec_env
@@ -10,31 +10,38 @@ from stable_baselines.common.vec_env import DummyVecEnv
 
 @pytest.mark.parametrize("cliprange", [0.2, lambda x: 0.1 * x])
 @pytest.mark.parametrize("cliprange_vf", [None, 0.2, lambda x: 0.3 * x, -1.0])
-def test_clipping(cliprange, cliprange_vf):
+def test_clipping(tmp_path, cliprange, cliprange_vf):
     """Test the different clipping (policy and vf)"""
-    model = PPO2('MlpPolicy', 'CartPole-v1',
-                 cliprange=cliprange, cliprange_vf=cliprange_vf,
-                 noptepochs=2, n_steps=64).learn(100)
-    model.save('./ppo2_clip.zip')
+    model = PPO2(
+        "MlpPolicy",
+        "CartPole-v1",
+        cliprange=cliprange,
+        cliprange_vf=cliprange_vf,
+        noptepochs=2,
+        n_steps=64,
+    ).learn(100)
+    save_path = os.path.join(str(tmp_path), "ppo2_clip.zip")
+    model.save(save_path)
     env = model.get_env()
-    model = PPO2.load('./ppo2_clip.zip', env=env)
+    model = PPO2.load(save_path, env=env)
     model.learn(100)
 
-    if os.path.exists('./ppo2_clip.zip'):
-        os.remove('./ppo2_clip.zip')
+    if os.path.exists(save_path):
+        os.remove(save_path)
+
 
 def test_ppo2_update_n_batch_on_load(tmp_path):
-    env = make_vec_env('CartPole-v1',n_envs=2)
-    model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
-    
-    model.learn(total_timesteps = 100)
-    model.save(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))
-    
+    env = make_vec_env("CartPole-v1", n_envs=2)
+    model = PPO2("MlpPolicy", env, n_steps=10, nminibatches=1)
+    save_path = os.path.join(str(tmp_path), "ppo2_cartpole.zip")
+
+    model.learn(total_timesteps=100)
+    model.save(save_path)
+
     del model
-    
-    model = PPO2.load(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))
-    test_env = DummyVecEnv([lambda: gym.make('CartPole-v1')])
-    
+
+    model = PPO2.load(save_path)
+    test_env = DummyVecEnv([lambda: gym.make("CartPole-v1")])
+
     model.set_env(test_env)
-    model.learn(total_timesteps = 100)
-    os.remove(os.path.join(str(tmp_path) , "ppo2_cartpole.zip"))
+    model.learn(total_timesteps=100)

--- a/tests/test_ppo2.py
+++ b/tests/test_ppo2.py
@@ -24,7 +24,7 @@ def test_clipping(cliprange, cliprange_vf):
     if os.path.exists('./ppo2_clip.zip'):
         os.remove('./ppo2_clip.zip')
 
-def test_update_n_batch_on_load(tmp_path):
+def test_ppo2_update_n_batch_on_load(tmp_path):
     env = make_vec_env('CartPole-v1',n_envs=2)
     model = PPO2('MlpPolicy', env, n_steps = 10, nminibatches=1)
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A patch fixing the ability of a loaded PPO2 model to further train on a vectorized environment of a different length than the one it was initially trained on. 

## Description

A test was added to test_ppo2.py which tests the ability of a loaded PPO2 model to train on a vectorized environment of a different length than the one it was initially trained on. 
set_env was overridden in ppo2.py to explicitly update n_batch to equal n_envs * n_steps as well as calling the set_env function of the super class.

## Motivation and Context
Prior to this patch, the code in the issue in the linked pull request will fail, the patch aims to fix that. 
closes #1132 
- [x] I have raised an issue to propose this change ([required](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've read the [CONTRIBUTION](https://github.com/hill-a/stable-baselines/blob/master/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the [changelog](https://github.com/hill-a/stable-baselines/blob/master/docs/misc/changelog.rst) accordingly (**required**).
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have ensured `pytest` and `pytype` both pass (by running  `make pytest` and `make type`).

<!--- This Template is an edited version of the one from https://github.com/evilsocket/pwnagotchi/ -->
